### PR TITLE
add a gauge set for CPU stats

### DIFF
--- a/core/src/main/java/com/spotify/metrics/jvm/CpuGaugeSet.java
+++ b/core/src/main/java/com/spotify/metrics/jvm/CpuGaugeSet.java
@@ -30,31 +30,31 @@ public class CpuGaugeSet implements SemanticMetricSet {
 
     final com.sun.management.OperatingSystemMXBean osMxBean = (com.sun.management.OperatingSystemMXBean) operatingSystemMXBean;
 
-    final Map<MetricId, Metric> gauges = new HashMap<MetricId, Metric>();
+    final Map<MetricId, Metric> gauges = new HashMap<>();
     final MetricId cpu = MetricId.build().tagged("what", "jvm-cpu-stats");
 
-    gauges.put(cpu.tagged("load", "process"), new Gauge<Double>() {
+    gauges.put(cpu.tagged("what", "process-cpu-load-percentage", "unit", "%"), new Gauge<Double>() {
       @Override
       public Double getValue() {
         return osMxBean.getProcessCpuLoad();
       }
     });
 
-    gauges.put(cpu.tagged("load", "system"), new Gauge<Double>() {
+    gauges.put(cpu.tagged("what", "system-cpu-load-percentage", "unit", "%"), new Gauge<Double>() {
       @Override
       public Double getValue() {
         return osMxBean.getSystemCpuLoad();
       }
     });
 
-    gauges.put(cpu.tagged("load", "system-average"), new Gauge<Double>() {
+    gauges.put(cpu.tagged("what", "system-load-average"), new Gauge<Double>() {
       @Override
       public Double getValue() {
         return osMxBean.getSystemLoadAverage();
       }
     });
 
-    gauges.put(cpu.tagged("cpu", "process-cpu-time"), new Gauge<Long>() {
+    gauges.put(cpu.tagged("what", "process-cpu-time", "unit", "ns"), new Gauge<Long>() {
       @Override
       public Long getValue() {
         return osMxBean.getProcessCpuTime();

--- a/core/src/main/java/com/spotify/metrics/jvm/CpuGaugeSet.java
+++ b/core/src/main/java/com/spotify/metrics/jvm/CpuGaugeSet.java
@@ -1,0 +1,70 @@
+package com.spotify.metrics.jvm;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Metric;
+import com.spotify.metrics.core.MetricId;
+import com.spotify.metrics.core.SemanticMetricSet;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.OperatingSystemMXBean;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A set of gauges reporting JVM CPU usage statistics.
+ */
+public class CpuGaugeSet implements SemanticMetricSet {
+
+  private final OperatingSystemMXBean operatingSystemMXBean;
+
+  private CpuGaugeSet(OperatingSystemMXBean operatingSystemMXBean) {
+    this.operatingSystemMXBean = operatingSystemMXBean;
+  }
+
+  @Override
+  public Map<MetricId, Metric> getMetrics() {
+    if (!(operatingSystemMXBean instanceof com.sun.management.OperatingSystemMXBean)) {
+      return Collections.emptyMap();
+    }
+
+    final com.sun.management.OperatingSystemMXBean osMxBean = (com.sun.management.OperatingSystemMXBean) operatingSystemMXBean;
+
+    final Map<MetricId, Metric> gauges = new HashMap<MetricId, Metric>();
+    final MetricId cpu = MetricId.build().tagged("what", "jvm-cpu-stats");
+
+    gauges.put(cpu.tagged("load", "process"), new Gauge<Double>() {
+      @Override
+      public Double getValue() {
+        return osMxBean.getProcessCpuLoad();
+      }
+    });
+
+    gauges.put(cpu.tagged("load", "system"), new Gauge<Double>() {
+      @Override
+      public Double getValue() {
+        return osMxBean.getSystemCpuLoad();
+      }
+    });
+
+    gauges.put(cpu.tagged("load", "system-average"), new Gauge<Double>() {
+      @Override
+      public Double getValue() {
+        return osMxBean.getSystemLoadAverage();
+      }
+    });
+
+    gauges.put(cpu.tagged("cpu", "process-cpu-time"), new Gauge<Long>() {
+      @Override
+      public Long getValue() {
+        return osMxBean.getProcessCpuTime();
+      }
+    });
+
+    return Collections.unmodifiableMap(gauges);
+  }
+
+  public static CpuGaugeSet create() {
+    return new CpuGaugeSet(ManagementFactory.getOperatingSystemMXBean());
+  }
+}

--- a/examples/src/main/java/com/spotify/metrics/example/JvmExample.java
+++ b/examples/src/main/java/com/spotify/metrics/example/JvmExample.java
@@ -24,6 +24,7 @@ package com.spotify.metrics.example;
 import com.spotify.metrics.core.MetricId;
 import com.spotify.metrics.core.SemanticMetricRegistry;
 import com.spotify.metrics.ffwd.FastForwardReporter;
+import com.spotify.metrics.jvm.CpuGaugeSet;
 import com.spotify.metrics.jvm.GarbageCollectorMetricSet;
 import com.spotify.metrics.jvm.MemoryUsageGaugeSet;
 import com.spotify.metrics.jvm.ThreadStatesMetricSet;
@@ -45,6 +46,7 @@ public class JvmExample {
         registry.register(MetricId.build("jvm-memory"), new MemoryUsageGaugeSet());
         registry.register(MetricId.build("jvm-gc"), new GarbageCollectorMetricSet());
         registry.register(MetricId.build("jvm-threads"), new ThreadStatesMetricSet());
+        registry.register(MetricId.build("jvm-cpu"), CpuGaugeSet.create());
 
         final FastForwardReporter reporter = FastForwardReporter
             .forRegistry(registry)


### PR DESCRIPTION
This allows you to track the CPU usage of the currently running process,
which is very useful for understanding the impact of changes between
versions of a service.