### PR TITLE
Initial support for remote metrics

### DIFF
--- a/api/src/main/java/com/spotify/metrics/core/RemoteCounter.java
+++ b/api/src/main/java/com/spotify/metrics/core/RemoteCounter.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2016 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.metrics.core;
+
+/**
+ * Like a coda hale Counter, but remoter.
+ */
+public interface RemoteCounter extends RemoteMetric {
+    void inc();
+    void inc(long n);
+    void dec();
+    void dec(long n);
+}

--- a/api/src/main/java/com/spotify/metrics/core/RemoteDerivingMeter.java
+++ b/api/src/main/java/com/spotify/metrics/core/RemoteDerivingMeter.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2016 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.metrics.core;
+
+/**
+ * Like a coda hale Meter, but remoter.
+ */
+public interface RemoteDerivingMeter extends RemoteMetric {
+    void mark();
+    void mark(long n);
+}

--- a/api/src/main/java/com/spotify/metrics/core/RemoteHistogram.java
+++ b/api/src/main/java/com/spotify/metrics/core/RemoteHistogram.java
@@ -19,31 +19,11 @@
  * under the License.
  */
 
-package com.spotify.metrics.remote;
-
-import com.google.common.collect.ImmutableMap;
-import com.spotify.metrics.core.MetricId;
-
-import java.util.Map;
+package com.spotify.metrics.core;
 
 /**
- * Utilities around building json blobs for sending to semantic aggregator.
+ * Like a coda hale Histogram, but remoter.
  */
-public class SemanticAggregator {
-
-    public static Map<String, String> buildAttributes(MetricId id, String type) {
-        ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
-        builder.putAll(id.getTags());
-        builder.put("metric_type", type);
-        return builder.build();
-    }
-
-    public static Map<String, Object> buildDocument(
-            String value, String key, Map<String, String> allAttributes) {
-        return ImmutableMap.of(
-                "type", "metric",
-                "value", value,
-                "key", key,
-                "attributes", allAttributes);
-    }
+public interface RemoteHistogram extends RemoteMetric {
+    void update(long value);
 }

--- a/api/src/main/java/com/spotify/metrics/core/RemoteMeter.java
+++ b/api/src/main/java/com/spotify/metrics/core/RemoteMeter.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2016 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.metrics.core;
+
+/**
+ * Like a coda hale Meter, but remoter.
+ */
+public interface RemoteMeter extends RemoteMetric {
+    void mark();
+    void mark(long n);
+}

--- a/api/src/main/java/com/spotify/metrics/core/RemoteMetric.java
+++ b/api/src/main/java/com/spotify/metrics/core/RemoteMetric.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2016 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.metrics.core;
+
+/**
+ * Like a coda hale Metric, but remoter.
+ */
+public interface RemoteMetric {
+}

--- a/api/src/main/java/com/spotify/metrics/core/RemoteSemanticMetricRegistry.java
+++ b/api/src/main/java/com/spotify/metrics/core/RemoteSemanticMetricRegistry.java
@@ -33,23 +33,23 @@ import java.util.List;
  */
 public interface RemoteSemanticMetricRegistry {
     /**
-     * Creates a new {@link RemoteCounter} and registers it under the given name.
+     * Creates a new {@link RemoteTimer} and registers it under the given name.
      * Sharding uses the "what"-tag of the metric Id.
      *
      * @param name the name of the metric
-     * @return a new {@link RemoteCounter}
+     * @return a new {@link RemoteTimer}
      */
-    RemoteCounter counter(final MetricId name);
+    RemoteTimer timer(final MetricId name);
 
     /**
-     * Creates a new {@link RemoteCounter} and registers it under the given name.
+     * Creates a new {@link RemoteTimer} and registers it under the given name.
      * Sharding uses the "what"-tag of the metric Id.
      *
      * @param name the name of the metric
      * @param shardKey the list of tags to be used for sharding
-     * @return a new {@link RemoteCounter}
+     * @return a new {@link RemoteTimer}
      */
-    RemoteCounter counter(final MetricId name, final List<String> shardKey);
+    RemoteTimer timer(final MetricId name, final List<String> shardKey);
 
     /**
      * Creates a new {@link RemoteMeter} and registers it under the given name.

--- a/api/src/main/java/com/spotify/metrics/core/RemoteSemanticMetricRegistry.java
+++ b/api/src/main/java/com/spotify/metrics/core/RemoteSemanticMetricRegistry.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2016 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.metrics.core;
+
+import java.util.List;
+
+/**
+ * Interface for arbitrary implementation of a MetricRegistry that
+ * does not need to be running locally in the current process. This
+ * API leaks less implementation details about how the metrics are
+ * implemented under the hood.
+ * <p>
+ * Currently, the SemanticAggregatorMetricRegistry is the only implementation.
+ */
+public interface RemoteSemanticMetricRegistry {
+    RemoteMeter meter(final MetricId name);
+
+    RemoteMeter meter(final MetricId name, final List<String> shardKey);
+}

--- a/api/src/main/java/com/spotify/metrics/core/RemoteSemanticMetricRegistry.java
+++ b/api/src/main/java/com/spotify/metrics/core/RemoteSemanticMetricRegistry.java
@@ -32,7 +32,59 @@ import java.util.List;
  * Currently, the SemanticAggregatorMetricRegistry is the only implementation.
  */
 public interface RemoteSemanticMetricRegistry {
+    /**
+     * Creates a new {@link RemoteMeter} and registers it under the given name.
+     * Sharding uses the "what"-tag of the metric Id.
+     *
+     * @param name the name of the metric
+     * @return a new {@link RemoteMeter}
+     */
     RemoteMeter meter(final MetricId name);
 
+    /**
+     * Creates a new {@link RemoteMeter} and registers it under the given name.
+     *
+     * @param name the name of the metric
+     * @param shardKey the list of tags to be used for sharding
+     * @return a new {@link RemoteMeter}
+     */
+    RemoteDerivingMeter derivingMeter(final MetricId name, final List<String> shardKey);
+
+    /**
+     * Creates a new {@link RemoteMeter} and registers it under the given name.
+     * Sharding uses the "what"-tag of the metric Id.
+     *
+     * @param name the name of the metric
+     * @return a new {@link RemoteMeter}
+     */
+    RemoteDerivingMeter derivingMeter(final MetricId name);
+
+    /**
+     * Creates a new {@link RemoteMeter} and registers it under the given name.
+     *
+     * @param name the name of the metric
+     * @param shardKey the list of tags to be used for sharding
+     * @return a new {@link RemoteMeter}
+     */
     RemoteMeter meter(final MetricId name, final List<String> shardKey);
+    /**
+     * Creates a new {@link RemoteCounter} and registers it under the given name.
+     * Sharding uses the "what"-tag of the metric Id.
+     *
+     * @param name the name of the metric
+     * @return a new {@link RemoteCounter}
+     */
+    RemoteCounter counter(final MetricId name);
+
+    /**
+     * Creates a new {@link RemoteCounter} and registers it under the given name.
+     * Sharding uses the "what"-tag of the metric Id.
+     *
+     * @param name the name of the metric
+     * @param shardKey the list of tags to be used for sharding
+     * @return a new {@link RemoteCounter}
+     */
+    RemoteCounter counter(final MetricId name, final List<String> shardKey);
+
+
 }

--- a/api/src/main/java/com/spotify/metrics/core/RemoteSemanticMetricRegistry.java
+++ b/api/src/main/java/com/spotify/metrics/core/RemoteSemanticMetricRegistry.java
@@ -33,13 +33,23 @@ import java.util.List;
  */
 public interface RemoteSemanticMetricRegistry {
     /**
-     * Creates a new {@link RemoteMeter} and registers it under the given name.
+     * Creates a new {@link RemoteCounter} and registers it under the given name.
      * Sharding uses the "what"-tag of the metric Id.
      *
      * @param name the name of the metric
-     * @return a new {@link RemoteMeter}
+     * @return a new {@link RemoteCounter}
      */
-    RemoteMeter meter(final MetricId name);
+    RemoteCounter counter(final MetricId name);
+
+    /**
+     * Creates a new {@link RemoteCounter} and registers it under the given name.
+     * Sharding uses the "what"-tag of the metric Id.
+     *
+     * @param name the name of the metric
+     * @param shardKey the list of tags to be used for sharding
+     * @return a new {@link RemoteCounter}
+     */
+    RemoteCounter counter(final MetricId name, final List<String> shardKey);
 
     /**
      * Creates a new {@link RemoteMeter} and registers it under the given name.
@@ -66,25 +76,32 @@ public interface RemoteSemanticMetricRegistry {
      * @param shardKey the list of tags to be used for sharding
      * @return a new {@link RemoteMeter}
      */
-    RemoteMeter meter(final MetricId name, final List<String> shardKey);
+    RemoteHistogram histogram(final MetricId name, final List<String> shardKey);
+
     /**
-     * Creates a new {@link RemoteCounter} and registers it under the given name.
+     * Creates a new {@link RemoteMeter} and registers it under the given name.
      * Sharding uses the "what"-tag of the metric Id.
      *
      * @param name the name of the metric
-     * @return a new {@link RemoteCounter}
+     * @return a new {@link RemoteMeter}
      */
-    RemoteCounter counter(final MetricId name);
+    RemoteHistogram histogram(final MetricId name);
 
     /**
-     * Creates a new {@link RemoteCounter} and registers it under the given name.
-     * Sharding uses the "what"-tag of the metric Id.
+     * Creates a new {@link RemoteMeter} and registers it under the given name.
      *
      * @param name the name of the metric
      * @param shardKey the list of tags to be used for sharding
-     * @return a new {@link RemoteCounter}
+     * @return a new {@link RemoteMeter}
      */
-    RemoteCounter counter(final MetricId name, final List<String> shardKey);
+    RemoteMeter meter(final MetricId name, final List<String> shardKey);
 
-
+    /**
+     * Creates a new {@link RemoteMeter} and registers it under the given name.
+     * Sharding uses the "what"-tag of the metric Id.
+     *
+     * @param name the name of the metric
+     * @return a new {@link RemoteMeter}
+     */
+    RemoteMeter meter(final MetricId name);
 }

--- a/api/src/main/java/com/spotify/metrics/core/RemoteTimer.java
+++ b/api/src/main/java/com/spotify/metrics/core/RemoteTimer.java
@@ -22,11 +22,13 @@
 package com.spotify.metrics.core;
 
 /**
- * Like a coda hale Counter, but remoter.
+ * Like a coda hale Timer, but remoter.
  */
-public interface RemoteCounter extends RemoteMetric {
-    void inc();
-    void inc(long n);
-    void dec();
-    void dec(long n);
+public interface RemoteTimer extends RemoteMetric {
+
+    Context time();
+
+    interface Context {
+        void stop();
+    }
 }

--- a/core/src/main/java/com/spotify/metrics/core/SemanticMetricBuilder.java
+++ b/core/src/main/java/com/spotify/metrics/core/SemanticMetricBuilder.java
@@ -83,7 +83,7 @@ public interface SemanticMetricBuilder<T extends Metric> {
     SemanticMetricBuilder<DerivingMeter> DERIVING_METERS =
         new SemanticMetricBuilder<DerivingMeter>() {
             @Override
-            public DerivingMeter newMetric() {
+            public DelegatingDerivingMeter newMetric() {
                 return new DelegatingDerivingMeter(new Meter());
             }
 

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
     <module>ffwd-reporter</module>
     <module>examples</module>
     <module>guava</module>
+    <module>remote</module>
   </modules>
 
   <properties>
@@ -104,6 +105,26 @@
         <artifactId>mockito-core</artifactId>
         <version>1.9.5</version>
         <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.squareup.okhttp3</groupId>
+        <artifactId>okhttp</artifactId>
+        <version>3.3.1</version>
+      </dependency>
+      <dependency>
+        <groupId>com.squareup.okhttp3</groupId>
+        <artifactId>mockwebserver</artifactId>
+        <version>3.3.1</version>
+      </dependency>
+      <dependency>
+        <groupId>com.spotify</groupId>
+        <artifactId>futures-extra</artifactId>
+        <version>2.6.0</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>2.7.4</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/remote/pom.xml
+++ b/remote/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>semantic-metrics-remote</artifactId>
+  <name>Semantic Metrics: Remote</name>
+
+  <parent>
+    <groupId>com.spotify.metrics</groupId>
+    <artifactId>semantic-metrics-parent</artifactId>
+    <version>0.5.2-SNAPSHOT</version>
+    <relativePath>..</relativePath>
+  </parent>
+
+  <description>
+    Semantic Metrics: Remote
+  </description>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.spotify.metrics</groupId>
+      <artifactId>semantic-metrics-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.spotify</groupId>
+      <artifactId>futures-extra</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+
+    <!-- testing -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>mockwebserver</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/remote/pom.xml
+++ b/remote/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.spotify.metrics</groupId>
     <artifactId>semantic-metrics-parent</artifactId>
-    <version>0.5.2-SNAPSHOT</version>
+    <version>0.6.1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/remote/src/main/java/com/spotify/metrics/remote/LimitedRemote.java
+++ b/remote/src/main/java/com/spotify/metrics/remote/LimitedRemote.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2016 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.metrics.remote;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import com.spotify.futures.ConcurrencyLimiter;
+
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+/**
+ * A remote that wraps another remote and limits both the number of
+ * requests in flight as well as the number of requests in queue.
+ */
+public class LimitedRemote implements Remote {
+
+    private final Remote inner;
+    private final ConcurrencyLimiter<Integer> tasks;
+
+    public LimitedRemote(Remote inner, int maxConcurrency, int highWaterMark) {
+        this.inner = inner;
+        tasks = ConcurrencyLimiter.create(maxConcurrency, highWaterMark);
+    }
+
+    @Override
+    public ListenableFuture<Integer> post(
+            final String path,
+            final String shardKey,
+            final Map json) {
+        return tasks.add(new Callable<ListenableFuture<Integer>>() {
+            @Override
+            public ListenableFuture<Integer> call() throws Exception {
+                return inner.post(path, shardKey, json);
+            }
+        });
+    }
+}

--- a/remote/src/main/java/com/spotify/metrics/remote/OkRemote.java
+++ b/remote/src/main/java/com/spotify/metrics/remote/OkRemote.java
@@ -68,7 +68,7 @@ public class OkRemote implements Remote {
         final RequestBody body = RequestBody.create(JSON, jsonStr);
         final Request request = new Request.Builder()
                 .url(url)
-                .addHeader("X-Shard-Key", shardKey)
+                .addHeader(Sharder.SHARD_KEY, shardKey)
                 .post(body)
                 .build();
         final SettableFuture<Integer> result = SettableFuture.create();

--- a/remote/src/main/java/com/spotify/metrics/remote/OkRemote.java
+++ b/remote/src/main/java/com/spotify/metrics/remote/OkRemote.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2016 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.metrics.remote;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+import okhttp3.OkHttpClient;
+import okhttp3.MediaType;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.Response;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Simple Remote implementation using OkHTTP
+ */
+public class OkRemote implements Remote {
+    private final OkHttpClient client = new OkHttpClient();
+    private static final MediaType JSON
+            = MediaType.parse("application/json; charset=utf-8");
+    private final String host;
+    private final int port;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    public OkRemote(String host, int port) {
+        this.host = host;
+        this.port = port;
+    }
+
+    @Override
+    public ListenableFuture<Integer> post(String path, String shardKey, Map jsonObj) {
+        if (path.indexOf(0) != '/') {
+            path = "/" + path;
+        }
+        final String jsonStr;
+        try {
+            jsonStr = mapper.writeValueAsString(jsonObj);
+        } catch (JsonProcessingException e) {
+            return Futures.immediateFailedFuture(new RuntimeException("Invalid json input"));
+        }
+        final String url = "http://" + host + ":" + port + path;
+        final RequestBody body = RequestBody.create(JSON, jsonStr);
+        final Request request = new Request.Builder()
+                .url(url)
+                .addHeader("X-Shard-Key", shardKey)
+                .post(body)
+                .build();
+        final SettableFuture<Integer> result = SettableFuture.create();
+        client.newCall(request).enqueue(new Callback() {
+            @Override
+            public void onFailure(Call call, IOException e) {
+                result.set(503);
+            }
+
+            @Override
+            public void onResponse(Call call, Response response) throws IOException {
+                result.set(response.code());
+            }
+        });
+        return result;
+    }
+}

--- a/remote/src/main/java/com/spotify/metrics/remote/OkRemote.java
+++ b/remote/src/main/java/com/spotify/metrics/remote/OkRemote.java
@@ -57,7 +57,7 @@ public class OkRemote implements Remote {
 
     @Override
     public ListenableFuture<Integer> post(String path, String shardKey, Map jsonObj) {
-        if (path.indexOf(0) != '/') {
+        if ((path.length() > 0) && (path.charAt(0) != '/')) {
             path = "/" + path;
         }
         final String jsonStr;
@@ -68,6 +68,7 @@ public class OkRemote implements Remote {
         }
         final String url = "http://" + host + ":" + port + path;
         final RequestBody body = RequestBody.create(JSON, jsonStr);
+
         final Request request = new Request.Builder()
             .url(url)
             .addHeader(Sharder.SHARD_KEY, shardKey)

--- a/remote/src/main/java/com/spotify/metrics/remote/OkRemote.java
+++ b/remote/src/main/java/com/spotify/metrics/remote/OkRemote.java
@@ -41,9 +41,11 @@ import java.util.Map;
  * Simple Remote implementation using OkHTTP
  */
 public class OkRemote implements Remote {
+    private static final String CONTENT_TYPE_KEY = "Content-Type";
+    private static final String CONTENT_TYPE_VALUE = "application/json";
     private final OkHttpClient client = new OkHttpClient();
     private static final MediaType JSON
-            = MediaType.parse("application/json; charset=utf-8");
+        = MediaType.parse("application/json; charset=utf-8");
     private final String host;
     private final int port;
     private final ObjectMapper mapper = new ObjectMapper();
@@ -67,10 +69,11 @@ public class OkRemote implements Remote {
         final String url = "http://" + host + ":" + port + path;
         final RequestBody body = RequestBody.create(JSON, jsonStr);
         final Request request = new Request.Builder()
-                .url(url)
-                .addHeader(Sharder.SHARD_KEY, shardKey)
-                .post(body)
-                .build();
+            .url(url)
+            .addHeader(Sharder.SHARD_KEY, shardKey)
+            .addHeader(CONTENT_TYPE_KEY, CONTENT_TYPE_VALUE)
+            .post(body)
+            .build();
         final SettableFuture<Integer> result = SettableFuture.create();
         client.newCall(request).enqueue(new Callback() {
             @Override

--- a/remote/src/main/java/com/spotify/metrics/remote/Remote.java
+++ b/remote/src/main/java/com/spotify/metrics/remote/Remote.java
@@ -26,7 +26,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import java.util.Map;
 
 /**
- * Interface for a remote server that we can send requests to
+ * Interface for a remote semantic aggregator instance that we can send requests to
  */
 public interface Remote {
     ListenableFuture<Integer> post(String path, String shardKey, Map json);

--- a/remote/src/main/java/com/spotify/metrics/remote/Remote.java
+++ b/remote/src/main/java/com/spotify/metrics/remote/Remote.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2016 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.metrics.remote;
+
+import com.google.common.util.concurrent.ListenableFuture;
+
+import java.util.Map;
+
+/**
+ * Interface for a remote server that we can send requests to
+ */
+public interface Remote {
+    ListenableFuture<Integer> post(String path, String shardKey, Map json);
+}

--- a/remote/src/main/java/com/spotify/metrics/remote/SemanticAggregator.java
+++ b/remote/src/main/java/com/spotify/metrics/remote/SemanticAggregator.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2016 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.metrics.remote;
+
+import com.google.common.collect.ImmutableMap;
+import com.spotify.metrics.core.MetricId;
+
+import java.util.Map;
+
+/**
+ * Utilities around building json blobs for sending to semantic aggregator.
+ */
+public class SemanticAggregator {
+
+    public static Map<String, String> buildAttributes (MetricId id, String type) {
+        ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+        builder.putAll(id.getTags());
+        builder.put("metric_type", type);
+        return builder.build();
+    }
+
+    public static Map<String, Object> buildDocument(String value, String key, Map<String, String> allAttributes) {
+        return ImmutableMap.of(
+                "type", "metric",
+                "value", value,
+                "key", key,
+                "attributes", allAttributes);
+    }
+}

--- a/remote/src/main/java/com/spotify/metrics/remote/SemanticAggregatorMetricBuilder.java
+++ b/remote/src/main/java/com/spotify/metrics/remote/SemanticAggregatorMetricBuilder.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2016 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.metrics.remote;
+
+import com.google.common.collect.ImmutableMap;
+import com.spotify.metrics.core.MetricId;
+import com.spotify.metrics.core.RemoteMeter;
+import com.spotify.metrics.core.RemoteMetric;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A builder for various remote Metric types.
+ *
+ * @param <T> Type of Metric to create
+ */
+public interface SemanticAggregatorMetricBuilder<T extends RemoteMetric> {
+    SemanticAggregatorMetricBuilder<RemoteMeter> REMOTE_METERS =
+            new SemanticAggregatorMetricBuilder<RemoteMeter>() {
+                @Override
+                public RemoteMeter newMetric(
+                        final MetricId id,
+                        final List<String> shardKey,
+                        final Remote remote) {
+
+                    ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+                    builder.putAll(id.getTags());
+                    builder.put("metric_type", "meter");
+
+                    final Map<String, String> allAttributes = builder.build();
+
+                    // Fixme(liljencrantz): This logic should live in separate class
+                    StringBuilder shardBuilder = new StringBuilder();
+                    for (String key : shardKey) {
+                        if (shardBuilder.length() != 0) {
+                            shardBuilder.append(',');
+                        }
+                        shardBuilder.append(httpHeaderEscape(key));
+                        shardBuilder.append(':');
+                        shardBuilder.append(httpHeaderEscape(allAttributes.get(key)));
+                    }
+                    final String shard = shardBuilder.toString();
+
+                    return new RemoteMeter() {
+                        @Override
+                        public void mark() {
+                            mark(1);
+                        }
+
+                        @Override
+                        public void mark(long n) {
+                            remote.post(
+                                    "/",
+                                    shard,
+                                    ImmutableMap.of(
+                                            "type", "metric",
+                                            "value", Long.toString(n),
+                                            "key", id.getKey(),
+                                            "attributes", allAttributes));
+                        }
+
+                    };
+                }
+
+                // Fixme(liljencrantz): This logic should live in separate class
+                private String httpHeaderEscape(String key) {
+                    StringBuilder res = new StringBuilder();
+                    for (char c : key.toCharArray()) {
+                        if (((c >= 'a' && c <= 'z')) || ((c >= 'A' && c <= 'Z'))) {
+                            res.append(c);
+                        }
+                    }
+                    return res.toString();
+                }
+
+                @Override
+                public boolean isInstance(final RemoteMetric metric) {
+                    return RemoteMeter.class.isInstance(metric);
+                }
+            };
+
+    T newMetric(MetricId id, List<String> shardKey, Remote remote);
+
+    boolean isInstance(final RemoteMetric metric);
+}

--- a/remote/src/main/java/com/spotify/metrics/remote/SemanticAggregatorMetricBuilder.java
+++ b/remote/src/main/java/com/spotify/metrics/remote/SemanticAggregatorMetricBuilder.java
@@ -21,7 +21,12 @@
 
 package com.spotify.metrics.remote;
 
-import com.spotify.metrics.core.*;
+import com.spotify.metrics.core.RemoteCounter;
+import com.spotify.metrics.core.RemoteHistogram;
+import com.spotify.metrics.core.RemoteMeter;
+import com.spotify.metrics.core.RemoteDerivingMeter;
+import com.spotify.metrics.core.RemoteMetric;
+import com.spotify.metrics.core.MetricId;
 
 import java.util.List;
 import java.util.Map;
@@ -33,132 +38,165 @@ import java.util.Map;
  */
 public interface SemanticAggregatorMetricBuilder<T extends RemoteMetric> {
     SemanticAggregatorMetricBuilder<RemoteMeter> REMOTE_METERS =
-            new SemanticAggregatorMetricBuilder<RemoteMeter>() {
-                @Override
-                public RemoteMeter newMetric(
-                        final MetricId id,
-                        final List<String> shardKey,
-                        final Remote remote) {
+        new SemanticAggregatorMetricBuilder<RemoteMeter>() {
+            @Override
+            public RemoteMeter newMetric(
+                final MetricId id,
+                final List<String> shardKey,
+                final Remote remote) {
 
-                    final Map<String, String> allAttributes =
-                            SemanticAggregator.buildAttributes(id, "meter");
-                    final String shard =
-                            Sharder.buildShardKey(shardKey, allAttributes);
+                final Map<String, String> allAttributes =
+                    SemanticAggregator.buildAttributes(id, "meter");
+                final String shard =
+                    Sharder.buildShardKey(shardKey, allAttributes);
 
-                    return new RemoteMeter() {
-                        @Override
-                        public void mark() {
-                            mark(1);
-                        }
+                return new RemoteMeter() {
+                    @Override
+                    public void mark() {
+                        mark(1);
+                    }
 
-                        @Override
-                        public void mark(long n) {
-                            remote.post(
-                                    "/",
-                                    shard,
-                                    SemanticAggregator.buildDocument(
-                                            Long.toString(n),
-                                            id.getKey(),
-                                            allAttributes));
-                        }
+                    @Override
+                    public void mark(long n) {
+                        remote.post(
+                            "/",
+                            shard,
+                            SemanticAggregator.buildDocument(
+                                Long.toString(n),
+                                id.getKey(),
+                                allAttributes));
+                    }
 
-                    };
-                }
+                };
+            }
 
-                @Override
-                public boolean isInstance(final RemoteMetric metric) {
-                    return RemoteMeter.class.isInstance(metric);
-                }
-            };
+            @Override
+            public boolean isInstance(final RemoteMetric metric) {
+                return RemoteMeter.class.isInstance(metric);
+            }
+        };
 
     SemanticAggregatorMetricBuilder<RemoteCounter> REMOTE_COUNTERS =
-            new SemanticAggregatorMetricBuilder<RemoteCounter>() {
-                @Override
-                public RemoteCounter newMetric(
-                        final MetricId id,
-                        final List<String> shardKey,
-                        final Remote remote) {
+        new SemanticAggregatorMetricBuilder<RemoteCounter>() {
+            @Override
+            public RemoteCounter newMetric(
+                final MetricId id,
+                final List<String> shardKey,
+                final Remote remote) {
 
-                    final Map<String, String> allAttributes =
-                            SemanticAggregator.buildAttributes(id, "counter");
-                    final String shard =
-                            Sharder.buildShardKey(shardKey, allAttributes);
+                final Map<String, String> allAttributes =
+                    SemanticAggregator.buildAttributes(id, "counter");
+                final String shard =
+                    Sharder.buildShardKey(shardKey, allAttributes);
 
-                    return new RemoteCounter() {
+                return new RemoteCounter() {
 
-                        @Override
-                        public void inc() {
-                            inc(1);
-                        }
+                    @Override
+                    public void inc() {
+                        inc(1);
+                    }
 
-                        @Override
-                        public void inc(long n) {
-                            remote.post(
-                                    "/",
-                                    shard,
-                                    SemanticAggregator.buildDocument(
-                                            Long.toString(n),
-                                            id.getKey(),
-                                            allAttributes));
-                        }
+                    @Override
+                    public void inc(long n) {
+                        remote.post(
+                            "/",
+                            shard,
+                            SemanticAggregator.buildDocument(
+                                Long.toString(n),
+                                id.getKey(),
+                                allAttributes));
+                    }
 
-                        @Override
-                        public void dec() {
-                            inc(-1);
-                        }
+                    @Override
+                    public void dec() {
+                        inc(-1);
+                    }
 
-                        @Override
-                        public void dec(long n) {
-                            inc(-n);
-                        }
+                    @Override
+                    public void dec(long n) {
+                        inc(-n);
+                    }
 
-                    };
-                }
+                };
+            }
 
-                @Override
-                public boolean isInstance(final RemoteMetric metric) {
-                    return RemoteCounter.class.isInstance(metric);
-                }
-            };
+            @Override
+            public boolean isInstance(final RemoteMetric metric) {
+                return RemoteCounter.class.isInstance(metric);
+            }
+        };
 
     SemanticAggregatorMetricBuilder<RemoteDerivingMeter> REMOTE_DERIVING_METERS =
-            new SemanticAggregatorMetricBuilder<RemoteDerivingMeter>() {
-                @Override
-                public RemoteDerivingMeter newMetric(
-                        final MetricId id,
-                        final List<String> shardKey,
-                        final Remote remote) {
+        new SemanticAggregatorMetricBuilder<RemoteDerivingMeter>() {
+            @Override
+            public RemoteDerivingMeter newMetric(
+                final MetricId id,
+                final List<String> shardKey,
+                final Remote remote) {
 
-                    final Map<String, String> allAttributes =
-                            SemanticAggregator.buildAttributes(id, "deriving_meter");
-                    final String shard =
-                            Sharder.buildShardKey(shardKey, allAttributes);
+                final Map<String, String> allAttributes =
+                    SemanticAggregator.buildAttributes(id, "deriving_meter");
+                final String shard =
+                    Sharder.buildShardKey(shardKey, allAttributes);
 
-                    return new RemoteDerivingMeter() {
-                        @Override
-                        public void mark() {
-                            mark(1);
-                        }
+                return new RemoteDerivingMeter() {
+                    @Override
+                    public void mark() {
+                        mark(1);
+                    }
 
-                        @Override
-                        public void mark(long n) {
-                            remote.post(
-                                    "/",
-                                    shard,
-                                    SemanticAggregator.buildDocument(
-                                            Long.toString(n),
-                                            id.getKey(),
-                                            allAttributes));
-                        }
+                    @Override
+                    public void mark(long n) {
+                        remote.post(
+                            "/",
+                            shard,
+                            SemanticAggregator.buildDocument(
+                                Long.toString(n),
+                                id.getKey(),
+                                allAttributes));
+                    }
 
-                    };
-                }
+                };
+            }
 
-                @Override
-                public boolean isInstance(final RemoteMetric metric) {
-                    return RemoteDerivingMeter.class.isInstance(metric);
-                }
-            };
+            @Override
+            public boolean isInstance(final RemoteMetric metric) {
+                return RemoteDerivingMeter.class.isInstance(metric);
+            }
+        };
+
+    SemanticAggregatorMetricBuilder<RemoteHistogram> REMOTE_HISTOGRAM =
+        new SemanticAggregatorMetricBuilder<RemoteHistogram>() {
+            @Override
+            public RemoteHistogram newMetric(
+                final MetricId id,
+                final List<String> shardKey,
+                final Remote remote) {
+
+                final Map<String, String> allAttributes =
+                    SemanticAggregator.buildAttributes(id, "histogram");
+                final String shard =
+                    Sharder.buildShardKey(shardKey, allAttributes);
+
+                return new RemoteHistogram() {
+                    @Override
+                    public void update(long value) {
+                        remote.post(
+                            "/",
+                            shard,
+                            SemanticAggregator.buildDocument(
+                                Long.toString(value),
+                                id.getKey(),
+                                allAttributes));
+                    }
+                };
+            }
+
+            @Override
+            public boolean isInstance(final RemoteMetric metric) {
+                return RemoteHistogram.class.isInstance(metric);
+            }
+        };
 
     T newMetric(MetricId id, List<String> shardKey, Remote remote);
 

--- a/remote/src/main/java/com/spotify/metrics/remote/SemanticAggregatorMetricBuilder.java
+++ b/remote/src/main/java/com/spotify/metrics/remote/SemanticAggregatorMetricBuilder.java
@@ -21,7 +21,7 @@
 
 package com.spotify.metrics.remote;
 
-import com.spotify.metrics.core.RemoteCounter;
+import com.spotify.metrics.core.RemoteTimer;
 import com.spotify.metrics.core.RemoteHistogram;
 import com.spotify.metrics.core.RemoteMeter;
 import com.spotify.metrics.core.RemoteDerivingMeter;
@@ -76,53 +76,18 @@ public interface SemanticAggregatorMetricBuilder<T extends RemoteMetric> {
             }
         };
 
-    SemanticAggregatorMetricBuilder<RemoteCounter> REMOTE_COUNTERS =
-        new SemanticAggregatorMetricBuilder<RemoteCounter>() {
+    SemanticAggregatorMetricBuilder<RemoteTimer> REMOTE_TIMERS =
+        new SemanticAggregatorMetricBuilder<RemoteTimer>() {
             @Override
-            public RemoteCounter newMetric(
-                final MetricId id,
-                final List<String> shardKey,
-                final Remote remote) {
-
-                final Map<String, String> allAttributes =
-                    SemanticAggregator.buildAttributes(id, "counter");
-                final String shard =
-                    Sharder.buildShardKey(shardKey, allAttributes);
-
-                return new RemoteCounter() {
-
-                    @Override
-                    public void inc() {
-                        inc(1);
-                    }
-
-                    @Override
-                    public void inc(long n) {
-                        remote.post(
-                            "/",
-                            shard,
-                            SemanticAggregator.buildDocument(
-                                Long.toString(n),
-                                id.getKey(),
-                                allAttributes));
-                    }
-
-                    @Override
-                    public void dec() {
-                        inc(-1);
-                    }
-
-                    @Override
-                    public void dec(long n) {
-                        inc(-n);
-                    }
-
-                };
+            public RemoteTimer newMetric(final MetricId id,
+                                         final List<String> shardKey,
+                                         final Remote remote) {
+                return new SemanticAggregatorTimer(id, shardKey, remote);
             }
 
             @Override
             public boolean isInstance(final RemoteMetric metric) {
-                return RemoteCounter.class.isInstance(metric);
+                return RemoteTimer.class.isInstance(metric);
             }
         };
 

--- a/remote/src/main/java/com/spotify/metrics/remote/SemanticAggregatorMetricRegistry.java
+++ b/remote/src/main/java/com/spotify/metrics/remote/SemanticAggregatorMetricRegistry.java
@@ -23,7 +23,7 @@ package com.spotify.metrics.remote;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
-import com.spotify.metrics.core.RemoteCounter;
+import com.spotify.metrics.core.RemoteTimer;
 import com.spotify.metrics.core.RemoteHistogram;
 import com.spotify.metrics.core.RemoteMeter;
 import com.spotify.metrics.core.RemoteDerivingMeter;
@@ -91,13 +91,13 @@ public class SemanticAggregatorMetricRegistry implements RemoteSemanticMetricReg
     }
 
     @Override
-    public RemoteCounter counter(MetricId name) {
-        return counter(name, ImmutableList.of("what"));
+    public RemoteTimer timer(MetricId name) {
+        return timer(name, ImmutableList.of("what"));
     }
 
     @Override
-    public RemoteCounter counter(MetricId name, List<String> shardKey) {
-        return getOrAdd(name, shardKey, SemanticAggregatorMetricBuilder.REMOTE_COUNTERS);
+    public RemoteTimer timer(MetricId name, List<String> shardKey) {
+        return getOrAdd(name, shardKey, SemanticAggregatorMetricBuilder.REMOTE_TIMERS);
     }
 
     @Override

--- a/remote/src/main/java/com/spotify/metrics/remote/SemanticAggregatorMetricRegistry.java
+++ b/remote/src/main/java/com/spotify/metrics/remote/SemanticAggregatorMetricRegistry.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2016 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.metrics.remote;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.spotify.metrics.core.MetricId;
+import com.spotify.metrics.core.RemoteMeter;
+import com.spotify.metrics.core.RemoteMetric;
+import com.spotify.metrics.core.RemoteSemanticMetricRegistry;
+
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * A registry of remote metric instances. Works just like
+ * SemanticMetricRegistry, but only deals with remote metrics.
+ */
+public class SemanticAggregatorMetricRegistry implements RemoteSemanticMetricRegistry {
+
+    private final Remote remote;
+    private final ConcurrentMap<MetricId, RemoteMetric> metrics;
+
+    public SemanticAggregatorMetricRegistry(
+            String remoteHost,
+            int port,
+            int maxConcurrency,
+            int hwm) {
+        this(new LimitedRemote(new OkRemote(remoteHost, port), maxConcurrency, hwm));
+    }
+
+    @VisibleForTesting
+    public SemanticAggregatorMetricRegistry(Remote remote) {
+        this.remote = remote;
+        metrics = new ConcurrentHashMap<>();
+    }
+
+    public <T extends RemoteMetric> T getOrAdd(
+            final MetricId name,
+            final List<String> shardKey,
+            final SemanticAggregatorMetricBuilder<T> builder
+    ) {
+        final RemoteMetric metric = metrics.get(name);
+
+        if (metric != null) {
+            if (!builder.isInstance(metric)) {
+                throw new IllegalArgumentException(
+                        name + " is already used for a different type of metric");
+            }
+
+            return (T) metric;
+        }
+
+        final T addition = builder.newMetric(name, shardKey, remote);
+
+        final RemoteMetric previous = metrics.putIfAbsent(name, addition);
+
+        if (previous == null) {
+            return addition;
+        }
+
+        if (!builder.isInstance(previous)) {
+            throw new IllegalArgumentException(
+                    name + " is already used for a different type of metric");
+        }
+
+        return (T) previous;
+    }
+
+    public RemoteMeter meter(final MetricId name) {
+        return meter(name, ImmutableList.of("what"));
+    }
+
+    public RemoteMeter meter(final MetricId name, final List<String> shardKey) {
+        return getOrAdd(name, shardKey, SemanticAggregatorMetricBuilder.REMOTE_METERS);
+    }
+}

--- a/remote/src/main/java/com/spotify/metrics/remote/SemanticAggregatorMetricRegistry.java
+++ b/remote/src/main/java/com/spotify/metrics/remote/SemanticAggregatorMetricRegistry.java
@@ -23,10 +23,7 @@ package com.spotify.metrics.remote;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
-import com.spotify.metrics.core.MetricId;
-import com.spotify.metrics.core.RemoteMeter;
-import com.spotify.metrics.core.RemoteMetric;
-import com.spotify.metrics.core.RemoteSemanticMetricRegistry;
+import com.spotify.metrics.core.*;
 
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
@@ -87,11 +84,33 @@ public class SemanticAggregatorMetricRegistry implements RemoteSemanticMetricReg
         return (T) previous;
     }
 
+    @Override
     public RemoteMeter meter(final MetricId name) {
         return meter(name, ImmutableList.of("what"));
     }
 
+    @Override
+    public RemoteDerivingMeter derivingMeter(MetricId name, List<String> shardKey) {
+        return getOrAdd(name, shardKey, SemanticAggregatorMetricBuilder.REMOTE_DERIVING_METERS);
+    }
+
+    @Override
+    public RemoteDerivingMeter derivingMeter(MetricId name) {
+        return derivingMeter(name, ImmutableList.of("what"));
+    }
+
+    @Override
     public RemoteMeter meter(final MetricId name, final List<String> shardKey) {
         return getOrAdd(name, shardKey, SemanticAggregatorMetricBuilder.REMOTE_METERS);
+    }
+
+    @Override
+    public RemoteCounter counter(MetricId name) {
+        return counter(name, ImmutableList.of("what"));
+    }
+
+    @Override
+    public RemoteCounter counter(MetricId name, List<String> shardKey) {
+        return getOrAdd(name, shardKey, SemanticAggregatorMetricBuilder.REMOTE_COUNTERS);
     }
 }

--- a/remote/src/main/java/com/spotify/metrics/remote/SemanticAggregatorTimer.java
+++ b/remote/src/main/java/com/spotify/metrics/remote/SemanticAggregatorTimer.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2016 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.metrics.remote;
+
+import com.spotify.metrics.core.MetricId;
+import com.spotify.metrics.core.RemoteTimer;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Remote implementation of a codahale Timer.
+ */
+public class SemanticAggregatorTimer implements RemoteTimer {
+
+    private static final TimeSource defaultTimeSource = new TimeSource() {
+        @Override
+        public long nanoTime() {
+            return System.nanoTime();
+        }
+    };
+    final String key;
+    final Remote remote;
+    final Map<String, String> allAttributes;
+    final String shard;
+    final TimeSource timeSource;
+
+    public SemanticAggregatorTimer(
+        final MetricId id,
+        final List<String> shardKey,
+        final Remote remote,
+        final TimeSource timeSource) {
+        this.key = id.getKey();
+        this.remote = remote;
+        this.timeSource = timeSource;
+        allAttributes = SemanticAggregator.buildAttributes(id, "timer");
+        shard = Sharder.buildShardKey(shardKey, allAttributes);
+    }
+
+    public SemanticAggregatorTimer(MetricId id, List<String> shardKey, Remote remote) {
+        this(id, shardKey, remote, defaultTimeSource);
+    }
+
+    @Override
+    public RemoteTimer.Context time() {
+        final long startTm = timeSource.nanoTime();
+        return new RemoteTimer.Context() {
+            @Override
+            public void stop() {
+                long stopTm = timeSource.nanoTime();
+                remote.post(
+                    "/",
+                    shard,
+                    SemanticAggregator.buildDocument(
+                        Long.toString(stopTm - startTm),
+                        key,
+                        allAttributes));
+            }
+        };
+    }
+
+    interface TimeSource {
+        long nanoTime();
+    }
+}

--- a/remote/src/main/java/com/spotify/metrics/remote/Sharder.java
+++ b/remote/src/main/java/com/spotify/metrics/remote/Sharder.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2016 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.metrics.remote;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Utilities around sharding monitoring events.
+ */
+public class Sharder {
+
+    public static final String SHARD_KEY = "X-Shard-Key";
+
+    public static String buildShardKey(List<String> shardKey, Map<String, String> values) {
+        StringBuilder shardBuilder = new StringBuilder();
+        for (String key : shardKey) {
+            if (shardBuilder.length() != 0) {
+                shardBuilder.append(',');
+            }
+            shardBuilder.append(httpHeaderEscape(key));
+            shardBuilder.append(':');
+            shardBuilder.append(httpHeaderEscape(values.get(key)));
+        }
+        return shardBuilder.toString();
+    }
+
+    public static String httpHeaderEscape(String key) {
+        StringBuilder res = new StringBuilder();
+        for (char c : key.toCharArray()) {
+            if (((c >= 'a' && c <= 'z')) || ((c >= 'A' && c <= 'Z'))) {
+                res.append(c);
+            }
+        }
+        return res.toString();
+    }
+
+}

--- a/remote/src/test/java/com/spotify/metrics/remote/LimitedRemoteTest.java
+++ b/remote/src/test/java/com/spotify/metrics/remote/LimitedRemoteTest.java
@@ -1,0 +1,82 @@
+package com.spotify.metrics.remote;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import static org.mockito.Matchers.anyMap;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LimitedRemoteTest {
+
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
+
+    @Mock
+    Remote inner;
+    Remote outer;
+
+    String url = "foo";
+    Map<String, Object> json = ImmutableMap.of("a", (Object) "b");
+    Map<String, Object> json2 = ImmutableMap.of("a", (Object) "c");
+    Map<String, Object> json3 = ImmutableMap.of("a", (Object) "d");
+    Map<String, Object> json4 = ImmutableMap.of("a", (Object) "e");
+
+    @Before
+    public void setUp() throws Exception {
+        outer = new LimitedRemote(inner, 1, 2);
+    }
+
+    @Test
+    public void createMeterTest() {
+        outer.post(url, "foo", json);
+        verify(inner).post(url, "foo", json);
+    }
+
+    @Test
+    public void blockMeterTest() throws Exception {
+        when(inner.post(anyString(), anyString(), anyMap())).thenAnswer(new Answer<Object>() {
+            @Override
+            public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+                return SettableFuture.<Integer>create();
+            }
+        });
+        outer.post(url, "foo", json);
+        outer.post(url, "foo", json2);
+        verify(inner, times(1)).post(eq(url), eq("foo"), anyMap());
+    }
+
+    @Test
+    public void overflowMeterTest() throws Exception {
+        when(inner.post(anyString(), anyString(), anyMap())).thenAnswer(new Answer<Object>() {
+            @Override
+            public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+                return SettableFuture.<Integer>create();
+            }
+        });
+        outer.post(url, "foo", json);
+        outer.post(url, "foo", json2);
+        outer.post(url, "foo", json3);
+        ListenableFuture<Integer> overflow = outer.post(url, "foo", json4);
+
+        assert (overflow.isDone());
+
+        exception.expect(ExecutionException.class);
+        overflow.get();
+    }
+
+}

--- a/remote/src/test/java/com/spotify/metrics/remote/OkRemoteTest.java
+++ b/remote/src/test/java/com/spotify/metrics/remote/OkRemoteTest.java
@@ -1,0 +1,44 @@
+package com.spotify.metrics.remote;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.ListenableFuture;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.Assert.assertEquals;
+
+public class OkRemoteTest {
+
+    Remote remote;
+    MockWebServer server;
+
+    @Before
+    public void setUp() {
+        server = new MockWebServer();
+        remote = new OkRemote(server.url("/").host(), server.url("/").port());
+    }
+
+    @Test
+    public void httpTest() throws InterruptedException, ExecutionException {
+        server.enqueue(new MockResponse().setBody("hia"));
+        ListenableFuture<Integer> result = remote.post("foo", "foo", ImmutableMap.of("aaa", "bbb"));
+        RecordedRequest r = server.takeRequest();
+        assertEquals("{\"aaa\":\"bbb\"}", r.getBody().readUtf8());
+        assertEquals(1, server.getRequestCount());
+        assertEquals("/foo", r.getPath());
+        assertEquals((Integer) 200, result.get());
+    }
+
+    @Test
+    public void shardTest() throws InterruptedException, ExecutionException {
+        server.enqueue(new MockResponse().setBody("hia"));
+        ListenableFuture<Integer> result = remote.post("foo", "shard-key", ImmutableMap.of());
+        RecordedRequest r = server.takeRequest();
+        assertEquals("shard-key", r.getHeader("X-Shard-Key"));
+    }
+}

--- a/remote/src/test/java/com/spotify/metrics/remote/SemanticAggregatorMetricRegistryTest.java
+++ b/remote/src/test/java/com/spotify/metrics/remote/SemanticAggregatorMetricRegistryTest.java
@@ -3,6 +3,7 @@ package com.spotify.metrics.remote;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.spotify.metrics.core.MetricId;
+import com.spotify.metrics.core.RemoteDerivingMeter;
 import com.spotify.metrics.core.RemoteMeter;
 import org.junit.Before;
 import org.junit.Test;
@@ -36,8 +37,7 @@ public class SemanticAggregatorMetricRegistryTest {
 
     @Test
     public void createMeterTest() {
-        RemoteMeter meter = registry.meter(MetricId.build("X").tagged("what", "balls"));
-        assertNotNull(meter);
+        assertNotNull(registry.meter(MetricId.build("X").tagged("what", "balls")));
     }
 
     @Test
@@ -77,9 +77,97 @@ public class SemanticAggregatorMetricRegistryTest {
     }
 
     @Test
-    public void uniquenessTest() {
+    public void meterUniquenessTest() {
         RemoteMeter a = registry.meter(MetricId.build("X").tagged("what", "balls", "status", "tripping"));
         RemoteMeter b = registry.meter(MetricId.build("X").tagged("what", "balls", "status", "tripping"));
+        assert (a == b);
+    }
+
+    @Test
+    public void createCounterTest() {
+        assertNotNull(registry.counter(MetricId.build("X").tagged("what", "balls")));
+    }
+
+    @Test
+    public void counterBump1Test() {
+        registry.counter(MetricId.build("X").tagged("what", "balls", "status", "tripping")).inc();
+        verify(remote).post("/", "what:balls",
+                ImmutableMap.of(
+                        "type", "metric",
+                        "value", "1",
+                        "key", "X",
+                        "attributes", ImmutableMap.of(
+                                "metric_type", "counter",
+                                "status", "tripping",
+                                "what", "balls")));
+    }
+
+    @Test
+    public void counterBump5Test() {
+        registry.counter(MetricId.build("X").tagged("what", "balls", "status", "tripping")).dec(5);
+        verify(remote).post("/", "what:balls",
+                ImmutableMap.of(
+                        "type", "metric",
+                        "value", "-5",
+                        "key", "X",
+                        "attributes", ImmutableMap.of(
+                                "metric_type", "counter",
+                                "status", "tripping",
+                                "what", "balls")));
+    }
+
+    @Test
+    public void counterUniquenessTest() {
+        RemoteMeter a = registry.meter(MetricId.build("X").tagged("what", "balls", "status", "tripping"));
+        RemoteMeter b = registry.meter(MetricId.build("X").tagged("what", "balls", "status", "tripping"));
+        assert (a == b);
+    }
+
+    @Test
+    public void createDerivingMeterTest() {
+        assertNotNull(registry.derivingMeter(MetricId.build("X").tagged("what", "balls")));
+    }
+
+    @Test
+    public void derivingMeterBump1Test() {
+        registry.derivingMeter(MetricId.build("X").tagged("what", "balls", "status", "tripping")).mark();
+        verify(remote).post("/", "what:balls",
+                ImmutableMap.of(
+                        "type", "metric",
+                        "value", "1",
+                        "key", "X",
+                        "attributes", ImmutableMap.of(
+                                "metric_type", "deriving_meter",
+                                "status", "tripping",
+                                "what", "balls")));
+    }
+
+    @Test
+    public void derivingMeterBump5Test() {
+        registry.derivingMeter(MetricId.build("X").tagged("what", "balls", "status", "tripping")).mark(5);
+        verify(remote).post("/", "what:balls",
+                ImmutableMap.of(
+                        "type", "metric",
+                        "value", "5",
+                        "key", "X",
+                        "attributes", ImmutableMap.of(
+                                "metric_type", "deriving_meter",
+                                "status", "tripping",
+                                "what", "balls")));
+    }
+
+    @Test
+    public void derivingMeterShardTest() {
+        registry.derivingMeter(
+                MetricId.build("X").tagged("what", "balls", "status", "tripping"),
+                ImmutableList.of("what", "status")).mark();
+        verify(remote).post(anyString(), eq("what:balls,status:tripping"), anyMap());
+    }
+
+    @Test
+    public void derivingMeterUniquenessTest() {
+        RemoteDerivingMeter a = registry.derivingMeter(MetricId.build("X").tagged("what", "balls", "status", "tripping"));
+        RemoteDerivingMeter b = registry.derivingMeter(MetricId.build("X").tagged("what", "balls", "status", "tripping"));
         assert (a == b);
     }
 }

--- a/remote/src/test/java/com/spotify/metrics/remote/SemanticAggregatorMetricRegistryTest.java
+++ b/remote/src/test/java/com/spotify/metrics/remote/SemanticAggregatorMetricRegistryTest.java
@@ -1,0 +1,85 @@
+package com.spotify.metrics.remote;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.spotify.metrics.core.MetricId;
+import com.spotify.metrics.core.RemoteMeter;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.anyMap;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+/**
+ * This test tests the SemanticAggregatorMetricRegistry and RemoteSementicMetricBuilder
+ * classes.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class SemanticAggregatorMetricRegistryTest {
+
+    @Mock
+    Remote remote;
+
+    SemanticAggregatorMetricRegistry registry;
+
+    @Before
+    public void setUp() throws Exception {
+        registry = spy(new SemanticAggregatorMetricRegistry(remote));
+    }
+
+    @Test
+    public void createMeterTest() {
+        RemoteMeter meter = registry.meter(MetricId.build("X").tagged("what", "balls"));
+        assertNotNull(meter);
+    }
+
+    @Test
+    public void meterBump1Test() {
+        registry.meter(MetricId.build("X").tagged("what", "balls", "status", "tripping")).mark();
+        verify(remote).post("/", "what:balls",
+                ImmutableMap.of(
+                        "type", "metric",
+                        "value", "1",
+                        "key", "X",
+                        "attributes", ImmutableMap.of(
+                                "metric_type", "meter",
+                                "status", "tripping",
+                                "what", "balls")));
+    }
+
+    @Test
+    public void meterBump5Test() {
+        registry.meter(MetricId.build("X").tagged("what", "balls", "status", "tripping")).mark(5);
+        verify(remote).post("/", "what:balls",
+                ImmutableMap.of(
+                        "type", "metric",
+                        "value", "5",
+                        "key", "X",
+                        "attributes", ImmutableMap.of(
+                                "metric_type", "meter",
+                                "status", "tripping",
+                                "what", "balls")));
+    }
+
+    @Test
+    public void meterShardTest() {
+        registry.meter(
+                MetricId.build("X").tagged("what", "balls", "status", "tripping"),
+                ImmutableList.of("what", "status")).mark();
+        verify(remote).post(anyString(), eq("what:balls,status:tripping"), anyMap());
+    }
+
+    @Test
+    public void uniquenessTest() {
+        RemoteMeter a = registry.meter(MetricId.build("X").tagged("what", "balls", "status", "tripping"));
+        RemoteMeter b = registry.meter(MetricId.build("X").tagged("what", "balls", "status", "tripping"));
+        assert (a == b);
+    }
+}

--- a/remote/src/test/java/com/spotify/metrics/remote/SharderTest.java
+++ b/remote/src/test/java/com/spotify/metrics/remote/SharderTest.java
@@ -1,0 +1,16 @@
+package com.spotify.metrics.remote;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class SharderTest {
+    @Test
+    public void shardKeyTest() {
+        String key = Sharder.buildShardKey(ImmutableList.of("what", "status"),
+                ImmutableMap.of("what","balls","status","tripping","site","lon"));
+        assertEquals("what:balls,status:tripping", key);
+    }
+}


### PR DESCRIPTION
This patch makes it possible to transmit
metrics to a remote SemanticAggregator
instance via http. It emulates the plain
SemanticMetrics API as much as possible.
Currently only supports meters, and no
support for HA via sharding.