### PR TITLE
Revert release 0.7.0 changes

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.spotify.metrics</groupId>
     <artifactId>semantic-metrics-parent</artifactId>
-    <version>0.7.0</version>
+    <version>0.6.1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.spotify.metrics</groupId>
     <artifactId>semantic-metrics-parent</artifactId>
-    <version>0.7.0</version>
+    <version>0.6.1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.spotify.metrics</groupId>
     <artifactId>semantic-metrics-parent</artifactId>
-    <version>0.7.0</version>
+    <version>0.6.1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/ffwd-reporter/pom.xml
+++ b/ffwd-reporter/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.spotify.metrics</groupId>
     <artifactId>semantic-metrics-parent</artifactId>
-    <version>0.7.0</version>
+    <version>0.6.1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.spotify.metrics</groupId>
     <artifactId>semantic-metrics-parent</artifactId>
-    <version>0.7.0</version>
+    <version>0.6.1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.spotify.metrics</groupId>
   <artifactId>semantic-metrics-parent</artifactId>
-  <version>0.7.0</version>
+  <version>0.6.1-SNAPSHOT</version>
   <name>Semantic Metrics: Parent POM</name>
   <packaging>pom</packaging>
 

--- a/remote/pom.xml
+++ b/remote/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.spotify.metrics</groupId>
     <artifactId>semantic-metrics-parent</artifactId>
-    <version>0.7.0</version>
+    <version>0.6.1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 


### PR DESCRIPTION
The version changes should be managed by maven-release-plugin instead of
performed manually. It's easier to address this by rolling back and let
the plugin do it for us.
My bad.