### PR TITLE
Add remote counters support

### DIFF
--- a/api/src/main/java/com/spotify/metrics/core/RemoteCounter.java
+++ b/api/src/main/java/com/spotify/metrics/core/RemoteCounter.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2017 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.metrics.core;
+
+/**
+ * Like a coda hale Counter, but remoter.
+ */
+public interface RemoteCounter extends RemoteMetric {
+    void inc();
+    void inc(long n);
+    void dec();
+    void dec(long n);
+}

--- a/api/src/main/java/com/spotify/metrics/core/RemoteSemanticMetricRegistry.java
+++ b/api/src/main/java/com/spotify/metrics/core/RemoteSemanticMetricRegistry.java
@@ -34,6 +34,25 @@ import java.util.concurrent.TimeUnit;
  */
 public interface RemoteSemanticMetricRegistry {
     /**
+     * Creates a new {@link RemoteCounter} and registers it under the given name.
+     * Sharding uses the "what"-tag of the metric Id.
+     *
+     * @param name the name of the metric
+     * @return a new {@link RemoteCounter}
+     */
+    RemoteCounter counter(final MetricId name);
+
+    /**
+     * Creates a new {@link RemoteCounter} and registers it under the given name.
+     * Sharding uses the "what"-tag of the metric Id.
+     *
+     * @param name the name of the metric
+     * @param shardKey the list of tags to be used for sharding
+     * @return a new {@link RemoteCounter}
+     */
+    RemoteCounter counter(final MetricId name, final List<String> shardKey);
+
+    /**
      * Creates a new {@link RemoteTimer} and registers it under the given name.
      * Sharding uses the "what"-tag of the metric Id.
      *

--- a/remote/src/main/java/com/spotify/metrics/remote/SemanticAggregatorMetricBuilder.java
+++ b/remote/src/main/java/com/spotify/metrics/remote/SemanticAggregatorMetricBuilder.java
@@ -23,6 +23,7 @@ package com.spotify.metrics.remote;
 
 import com.google.common.util.concurrent.ListenableFuture;
 
+import com.spotify.metrics.core.RemoteCounter;
 import com.spotify.metrics.core.RemoteTimer;
 import com.spotify.metrics.core.RemoteHistogram;
 import com.spotify.metrics.core.RemoteMeter;
@@ -75,6 +76,55 @@ public interface SemanticAggregatorMetricBuilder<T extends RemoteMetric> {
             @Override
             public boolean isInstance(final RemoteMetric metric) {
                 return RemoteMeter.class.isInstance(metric);
+            }
+        };
+
+    SemanticAggregatorMetricBuilder<RemoteCounter> REMOTE_COUNTERS =
+        new SemanticAggregatorMetricBuilder<RemoteCounter>() {
+            @Override
+            public RemoteCounter newMetric(
+                final MetricId id,
+                final List<String> shardKey,
+                final Remote remote) {
+
+                final Map<String, String> allAttributes =
+                    SemanticAggregator.buildAttributes(id, "counter");
+                final String shard =
+                    Sharder.buildShardKey(shardKey, allAttributes);
+
+                return new RemoteCounter() {
+                    @Override
+                    public void inc() {
+                        inc(1);
+                    }
+
+                    @Override
+                    public void inc(long n) {
+                        remote.post(
+                            "/",
+                            shard,
+                            SemanticAggregator.buildDocument(
+                                Long.toString(n),
+                                id.getKey(),
+                                allAttributes));
+                    }
+
+                    @Override
+                    public void dec() {
+                        inc(-1);
+                    }
+
+                    @Override
+                    public void dec(long n) {
+                        inc(-n);
+                    }
+
+                };
+            }
+
+            @Override
+            public boolean isInstance(final RemoteMetric metric) {
+                return RemoteCounter.class.isInstance(metric);
             }
         };
 

--- a/remote/src/main/java/com/spotify/metrics/remote/SemanticAggregatorMetricRegistry.java
+++ b/remote/src/main/java/com/spotify/metrics/remote/SemanticAggregatorMetricRegistry.java
@@ -23,6 +23,7 @@ package com.spotify.metrics.remote;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import com.spotify.metrics.core.RemoteCounter;
 import com.spotify.metrics.core.RemoteTimer;
 import com.spotify.metrics.core.RemoteHistogram;
 import com.spotify.metrics.core.RemoteMeter;
@@ -89,6 +90,16 @@ public class SemanticAggregatorMetricRegistry implements RemoteSemanticMetricReg
         }
 
         return (T) previous;
+    }
+
+    @Override
+    public RemoteCounter counter(MetricId name) {
+        return counter(name, ImmutableList.of("what"));
+    }
+
+    @Override
+    public RemoteCounter counter(MetricId name, List<String> shardKey) {
+        return getOrAdd(name, shardKey, SemanticAggregatorMetricBuilder.REMOTE_COUNTERS);
     }
 
     @Override


### PR DESCRIPTION
Remote counters support was dropped in https://github.com/spotify/semantic-metrics/pull/4/commits/a605ed4038efd53bc61d3debf20614d11b9bf8ae but we still want it, so here I re-introduce them.