### PR TITLE
Add wait for async calls

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -31,7 +31,6 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/api/src/main/java/com/spotify/metrics/core/RemoteDerivingMeter.java
+++ b/api/src/main/java/com/spotify/metrics/core/RemoteDerivingMeter.java
@@ -21,10 +21,12 @@
 
 package com.spotify.metrics.core;
 
+import com.google.common.util.concurrent.ListenableFuture;
+
 /**
  * Like a coda hale Meter, but remoter.
  */
 public interface RemoteDerivingMeter extends RemoteMetric {
-    void mark();
-    void mark(long n);
+    ListenableFuture<Integer> mark();
+    ListenableFuture<Integer> mark(long n);
 }

--- a/api/src/main/java/com/spotify/metrics/core/RemoteHistogram.java
+++ b/api/src/main/java/com/spotify/metrics/core/RemoteHistogram.java
@@ -21,9 +21,11 @@
 
 package com.spotify.metrics.core;
 
+import com.google.common.util.concurrent.ListenableFuture;
+
 /**
  * Like a coda hale Histogram, but remoter.
  */
 public interface RemoteHistogram extends RemoteMetric {
-    void update(long value);
+    ListenableFuture<Integer> update(long value);
 }

--- a/api/src/main/java/com/spotify/metrics/core/RemoteMeter.java
+++ b/api/src/main/java/com/spotify/metrics/core/RemoteMeter.java
@@ -21,10 +21,12 @@
 
 package com.spotify.metrics.core;
 
+import com.google.common.util.concurrent.ListenableFuture;
+
 /**
  * Like a coda hale Meter, but remoter.
  */
 public interface RemoteMeter extends RemoteMetric {
-    void mark();
-    void mark(long n);
+    ListenableFuture<Integer> mark();
+    ListenableFuture<Integer> mark(long n);
 }

--- a/api/src/main/java/com/spotify/metrics/core/RemoteSemanticMetricRegistry.java
+++ b/api/src/main/java/com/spotify/metrics/core/RemoteSemanticMetricRegistry.java
@@ -104,4 +104,9 @@ public interface RemoteSemanticMetricRegistry {
      * @return a new {@link RemoteMeter}
      */
     RemoteMeter meter(final MetricId name);
+
+    /**
+     * Wait for all metrics to be sent to the remote.
+     */
+    void waitForAllCalls();
 }

--- a/api/src/main/java/com/spotify/metrics/core/RemoteSemanticMetricRegistry.java
+++ b/api/src/main/java/com/spotify/metrics/core/RemoteSemanticMetricRegistry.java
@@ -22,6 +22,7 @@
 package com.spotify.metrics.core;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Interface for arbitrary implementation of a MetricRegistry that
@@ -106,7 +107,13 @@ public interface RemoteSemanticMetricRegistry {
     RemoteMeter meter(final MetricId name);
 
     /**
-     * Wait for all metrics to be sent to the remote.
+     * Stop accepting new metrics to be sent and wait for all asynchronous calls
+     * to be done or the timeout to occur.
+     *
+     * @param timeout For how long to wait for asynchronous requests
+     * @param timeUnit The unit of the timeout
+     * @return False if the timeout occurred before all requests were completed
+     * @throws InterruptedException if the wait was interrupted
      */
-    void waitForAllCalls();
+    boolean shutdown(long timeout, TimeUnit timeUnit) throws InterruptedException;
 }

--- a/api/src/main/java/com/spotify/metrics/core/RemoteTimer.java
+++ b/api/src/main/java/com/spotify/metrics/core/RemoteTimer.java
@@ -21,6 +21,8 @@
 
 package com.spotify.metrics.core;
 
+import com.google.common.util.concurrent.ListenableFuture;
+
 /**
  * Like a coda hale Timer, but remoter.
  */
@@ -29,6 +31,6 @@ public interface RemoteTimer extends RemoteMetric {
     Context time();
 
     interface Context {
-        void stop();
+        ListenableFuture<Integer> stop();
     }
 }

--- a/remote/src/main/java/com/spotify/metrics/remote/LimitedRemote.java
+++ b/remote/src/main/java/com/spotify/metrics/remote/LimitedRemote.java
@@ -26,6 +26,7 @@ import com.spotify.futures.ConcurrencyLimiter;
 
 import java.util.Map;
 import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 
 /**
  * A remote that wraps another remote and limits both the number of
@@ -55,7 +56,7 @@ public class LimitedRemote implements Remote {
     }
 
     @Override
-    public void waitForAllCalls() {
-        inner.waitForAllCalls();
+    public boolean shutdown(long timeout, TimeUnit timeUnit) throws InterruptedException {
+        return inner.shutdown(timeout, timeUnit);
     }
 }

--- a/remote/src/main/java/com/spotify/metrics/remote/LimitedRemote.java
+++ b/remote/src/main/java/com/spotify/metrics/remote/LimitedRemote.java
@@ -53,4 +53,9 @@ public class LimitedRemote implements Remote {
             }
         });
     }
+
+    @Override
+    public void waitForAllCalls() {
+        inner.waitForAllCalls();
+    }
 }

--- a/remote/src/main/java/com/spotify/metrics/remote/OkRemote.java
+++ b/remote/src/main/java/com/spotify/metrics/remote/OkRemote.java
@@ -93,6 +93,7 @@ public class OkRemote implements Remote {
             @Override
             public void onResponse(Call call, Response response) throws IOException {
                 result.set(response.code());
+                response.close();
             }
         });
         return result;

--- a/remote/src/main/java/com/spotify/metrics/remote/OkRemote.java
+++ b/remote/src/main/java/com/spotify/metrics/remote/OkRemote.java
@@ -27,6 +27,9 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import okhttp3.Dispatcher;
 import okhttp3.OkHttpClient;
 import okhttp3.MediaType;
@@ -44,6 +47,8 @@ import java.util.concurrent.TimeUnit;
  * Simple Remote implementation using OkHTTP
  */
 public class OkRemote implements Remote {
+    private static final Logger log = LoggerFactory.getLogger(OkRemote.class);
+
     private static final String CONTENT_TYPE_KEY = "Content-Type";
     private static final String CONTENT_TYPE_VALUE = "application/json";
     private final OkHttpClient client = new OkHttpClient();
@@ -62,7 +67,8 @@ public class OkRemote implements Remote {
     @Override
     public synchronized ListenableFuture<Integer> post(String path, String shardKey, Map jsonObj) {
         if (closed) {
-            throw new RuntimeException("Calling post after shutdown");
+            log.warn("Calling post after shutdown. Call will be ignored.");
+            return Futures.immediateCancelledFuture();
         }
 
         if ((path.length() > 0) && (path.charAt(0) != '/')) {

--- a/remote/src/main/java/com/spotify/metrics/remote/OkRemote.java
+++ b/remote/src/main/java/com/spotify/metrics/remote/OkRemote.java
@@ -100,9 +100,10 @@ public class OkRemote implements Remote {
     }
 
     @Override
-    public synchronized boolean shutdown(long timeout, TimeUnit timeUnit)
-            throws InterruptedException {
-        closed = true;
+    public boolean shutdown(long timeout, TimeUnit timeUnit) throws InterruptedException {
+        synchronized (this) {
+            closed = true;
+        }
         Dispatcher dispatcher = client.dispatcher();
         long millis = timeUnit.toMillis(timeout);
         long expirationTime = System.currentTimeMillis() + millis;

--- a/remote/src/main/java/com/spotify/metrics/remote/OkRemote.java
+++ b/remote/src/main/java/com/spotify/metrics/remote/OkRemote.java
@@ -104,8 +104,8 @@ public class OkRemote implements Remote {
             throws InterruptedException {
         closed = true;
         Dispatcher dispatcher = client.dispatcher();
-        long nanos = timeUnit.toNanos(timeout);
-        long expirationTime = System.currentTimeMillis() + nanos;
+        long millis = timeUnit.toMillis(timeout);
+        long expirationTime = System.currentTimeMillis() + millis;
         while (dispatcher.queuedCallsCount() != 0 || dispatcher.runningCallsCount() != 0) {
             if (System.currentTimeMillis() > expirationTime) {
                 return false;

--- a/remote/src/main/java/com/spotify/metrics/remote/OkRemote.java
+++ b/remote/src/main/java/com/spotify/metrics/remote/OkRemote.java
@@ -26,6 +26,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
+
+import okhttp3.Dispatcher;
 import okhttp3.OkHttpClient;
 import okhttp3.MediaType;
 import okhttp3.Request;
@@ -88,5 +90,18 @@ public class OkRemote implements Remote {
             }
         });
         return result;
+    }
+
+    @Override
+    public void waitForAllCalls() {
+        Dispatcher dispatcher = client.dispatcher();
+        while (dispatcher.queuedCallsCount() != 0 || dispatcher.runningCallsCount() != 0) {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
     }
 }

--- a/remote/src/main/java/com/spotify/metrics/remote/Remote.java
+++ b/remote/src/main/java/com/spotify/metrics/remote/Remote.java
@@ -24,11 +24,12 @@ package com.spotify.metrics.remote;
 import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Interface for a remote semantic aggregator instance that we can send requests to
  */
 public interface Remote {
     ListenableFuture<Integer> post(String path, String shardKey, Map json);
-    void waitForAllCalls();
+    boolean shutdown(long timeout, TimeUnit timeUnit) throws InterruptedException;
 }

--- a/remote/src/main/java/com/spotify/metrics/remote/Remote.java
+++ b/remote/src/main/java/com/spotify/metrics/remote/Remote.java
@@ -30,4 +30,5 @@ import java.util.Map;
  */
 public interface Remote {
     ListenableFuture<Integer> post(String path, String shardKey, Map json);
+    void waitForAllCalls();
 }

--- a/remote/src/main/java/com/spotify/metrics/remote/SemanticAggregatorMetricBuilder.java
+++ b/remote/src/main/java/com/spotify/metrics/remote/SemanticAggregatorMetricBuilder.java
@@ -21,6 +21,8 @@
 
 package com.spotify.metrics.remote;
 
+import com.google.common.util.concurrent.ListenableFuture;
+
 import com.spotify.metrics.core.RemoteTimer;
 import com.spotify.metrics.core.RemoteHistogram;
 import com.spotify.metrics.core.RemoteMeter;
@@ -52,13 +54,13 @@ public interface SemanticAggregatorMetricBuilder<T extends RemoteMetric> {
 
                 return new RemoteMeter() {
                     @Override
-                    public void mark() {
-                        mark(1);
+                    public ListenableFuture<Integer> mark() {
+                        return mark(1);
                     }
 
                     @Override
-                    public void mark(long n) {
-                        remote.post(
+                    public ListenableFuture<Integer> mark(long n) {
+                        return remote.post(
                             "/",
                             shard,
                             SemanticAggregator.buildDocument(
@@ -106,13 +108,13 @@ public interface SemanticAggregatorMetricBuilder<T extends RemoteMetric> {
 
                 return new RemoteDerivingMeter() {
                     @Override
-                    public void mark() {
-                        mark(1);
+                    public ListenableFuture<Integer> mark() {
+                        return mark(1);
                     }
 
                     @Override
-                    public void mark(long n) {
-                        remote.post(
+                    public ListenableFuture<Integer> mark(long n) {
+                        return remote.post(
                             "/",
                             shard,
                             SemanticAggregator.buildDocument(
@@ -145,8 +147,8 @@ public interface SemanticAggregatorMetricBuilder<T extends RemoteMetric> {
 
                 return new RemoteHistogram() {
                     @Override
-                    public void update(long value) {
-                        remote.post(
+                    public ListenableFuture<Integer> update(long value) {
+                        return remote.post(
                             "/",
                             shard,
                             SemanticAggregator.buildDocument(

--- a/remote/src/main/java/com/spotify/metrics/remote/SemanticAggregatorMetricRegistry.java
+++ b/remote/src/main/java/com/spotify/metrics/remote/SemanticAggregatorMetricRegistry.java
@@ -34,6 +34,7 @@ import com.spotify.metrics.core.RemoteSemanticMetricRegistry;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
 
 /**
  * A registry of remote metric instances. Works just like
@@ -131,7 +132,7 @@ public class SemanticAggregatorMetricRegistry implements RemoteSemanticMetricReg
     }
 
     @Override
-    public void waitForAllCalls() {
-        remote.waitForAllCalls();
+    public boolean shutdown(long timeout, TimeUnit timeUnit) throws InterruptedException {
+        return remote.shutdown(timeout, timeUnit);
     }
 }

--- a/remote/src/main/java/com/spotify/metrics/remote/SemanticAggregatorMetricRegistry.java
+++ b/remote/src/main/java/com/spotify/metrics/remote/SemanticAggregatorMetricRegistry.java
@@ -130,4 +130,8 @@ public class SemanticAggregatorMetricRegistry implements RemoteSemanticMetricReg
         return getOrAdd(name, shardKey, SemanticAggregatorMetricBuilder.REMOTE_METERS);
     }
 
+    @Override
+    public void waitForAllCalls() {
+        remote.waitForAllCalls();
+    }
 }

--- a/remote/src/main/java/com/spotify/metrics/remote/SemanticAggregatorTimer.java
+++ b/remote/src/main/java/com/spotify/metrics/remote/SemanticAggregatorTimer.java
@@ -21,6 +21,8 @@
 
 package com.spotify.metrics.remote;
 
+import com.google.common.util.concurrent.ListenableFuture;
+
 import com.spotify.metrics.core.MetricId;
 import com.spotify.metrics.core.RemoteTimer;
 
@@ -65,9 +67,9 @@ public class SemanticAggregatorTimer implements RemoteTimer {
         final long startTm = timeSource.nanoTime();
         return new RemoteTimer.Context() {
             @Override
-            public void stop() {
+            public ListenableFuture<Integer> stop() {
                 long stopTm = timeSource.nanoTime();
-                remote.post(
+                return remote.post(
                     "/",
                     shard,
                     SemanticAggregator.buildDocument(


### PR DESCRIPTION
Http requests are executed asynchronously using OkHttpClient. This
can lead to some metrics being lost when shutting down the JVM.
Add some logic to wait for all calls to be executed so clients
can wait for all metrics to be sent.