### PR TITLE
Wrap fileDescriptorRatioGauge which breaks in java9

### DIFF
--- a/core/src/main/java/com/spotify/metrics/jvm/FileDescriptorGaugeSet.java
+++ b/core/src/main/java/com/spotify/metrics/jvm/FileDescriptorGaugeSet.java
@@ -55,7 +55,7 @@ public class FileDescriptorGaugeSet implements SemanticMetricSet {
                     // which does not exist in Java 8, therefore return 0.
                     try {
                         return fileDescriptorRatioGauge.getValue();
-                    } catch(Exception e) {
+                    } catch (Exception e) {
                         return 0;
                     }
             }

--- a/core/src/main/java/com/spotify/metrics/jvm/FileDescriptorGaugeSet.java
+++ b/core/src/main/java/com/spotify/metrics/jvm/FileDescriptorGaugeSet.java
@@ -51,7 +51,13 @@ public class FileDescriptorGaugeSet implements SemanticMetricSet {
         gauges.put(metricId, new Gauge<Object>() {
             @Override
             public Object getValue() {
-                return fileDescriptorRatioGauge.getValue();
+                    // Java 9 will throw java.lang.reflect.InaccessibleObjectException
+                    // which does not exist in Java 8, therefore return 0.
+                    try {
+                        return fileDescriptorRatioGauge.getValue();
+                    } catch(Exception e) {
+                        return 0;
+                    }
             }
         });
         return Collections.unmodifiableMap(gauges);

--- a/core/src/main/java/com/spotify/metrics/jvm/FileDescriptorGaugeSet.java
+++ b/core/src/main/java/com/spotify/metrics/jvm/FileDescriptorGaugeSet.java
@@ -55,7 +55,7 @@ public class FileDescriptorGaugeSet implements SemanticMetricSet {
                     // which does not exist in Java 8, therefore return 0.
                     try {
                         return fileDescriptorRatioGauge.getValue();
-                    } catch (Exception e) {
+                    } catch (final Exception e) {
                         return 0;
                     }
             }


### PR DESCRIPTION
Java9 fails with `InaccessibleObjectException` which causes all metric
reporting to fail. This is a new exception in java9 so we can't catch it
in Java8, simply return 0 if exception is thrown. This is tested in
java8/java9

```
java.lang.reflect.InaccessibleObjectException: Unable to make public long com.sun.management.internal.OperatingSystemImpl.getOpenFileDescriptorCount() accessible: module jdk.management does not "opens com.sun.management.internal" to unnamed module @385c9627
```