### PR TITLE
report metric counter

### DIFF
--- a/ffwd-reporter/src/main/java/com/spotify/metrics/ffwd/FastForwardReporter.java
+++ b/ffwd-reporter/src/main/java/com/spotify/metrics/ffwd/FastForwardReporter.java
@@ -22,6 +22,7 @@
 package com.spotify.metrics.ffwd;
 
 import com.codahale.metrics.Counter;
+import com.codahale.metrics.Counting;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
@@ -239,7 +240,7 @@ public class FastForwardReporter implements AutoCloseable {
         return 0;
     }
 
-    private void reportCounter(MetricId key, Counter value) {
+    private void reportCounter(MetricId key, Counting value) {
         key = MetricId.join(prefix, key);
 
         final Metric m = FastForward
@@ -270,6 +271,7 @@ public class FastForwardReporter implements AutoCloseable {
             .attribute(METRIC_TYPE, "meter");
 
         reportMetered(m, value);
+        reportCounter(key, value);
     }
 
     private void reportTimer(MetricId key, Timer value) {


### PR DESCRIPTION
Report the meter counter value to allow platforms to derive rates using the monotonically increasing count instead of only aggregating the rate computed by the meter itself. Although this can be achieved by simply completely replacing the meter with a counter, it is useful for applications to be able to report both count and rate using a meter.

For reference, see the `JmxMeter` https://github.com/dropwizard/metrics/blob/3.1-maintenance/metrics-core/src/main/java/com/codahale/metrics/JmxReporter.java#L320