### PR TITLE
[WIP] Add support for tag extraction.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -37,7 +37,12 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
 
-    <!-- testing -->
+    <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+    </dependency>
+
+      <!-- testing -->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
@@ -46,11 +51,6 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/core/src/main/java/com/spotify/metrics/tags/EnvironmentTagExtractor.java
+++ b/core/src/main/java/com/spotify/metrics/tags/EnvironmentTagExtractor.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2018 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.metrics.tags;
+
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Extract tags from the system environment variables.
+ *
+ */
+public class EnvironmentTagExtractor implements TagExtractor {
+
+    /**
+     * Prefix of environment variable that adds additional tags.
+     */
+    public static final String FFWD_TAG_PREFIX = "FFWD_TAG_";
+
+    public static Map<String, String> environmentTags;
+
+    public EnvironmentTagExtractor() {
+        this(Suppliers.ofInstance(System.getenv()));
+    }
+
+    public EnvironmentTagExtractor(Supplier<Map<String, String>> enviromentSupplier) {
+        this.environmentTags = filterEnvironmentTags(enviromentSupplier.get());
+    }
+
+    /**
+     * Extract tags from the system environment variables.
+     * Tags extracted from the environment takes precedence and overwrites existing tags
+     * with the same key.
+     *
+     * @return map with extracted tags added.
+     */
+    @Override
+    public Map<String, String> addTags(Map<String, String> tags) {
+        final Map<String, String> extractedTags = new HashMap<>(tags);
+        extractedTags.putAll(environmentTags);
+        return extractedTags;
+    }
+
+    /**
+     * Extract tags from a map that can correspond to system environment variables.
+     *
+     * @return extracted tags.
+     */
+    public static Map<String, String> filterEnvironmentTags(final Map<String, String> env) {
+        final Map<String, String> tags = new HashMap<>();
+
+        for (final Map.Entry<String, String> e : env.entrySet()) {
+            if (e.getKey().startsWith(FFWD_TAG_PREFIX)) {
+                final String tag = e.getKey().substring(FFWD_TAG_PREFIX.length());
+                tags.put(tag.toLowerCase(), e.getValue());
+            }
+        }
+
+        return tags;
+    }
+}

--- a/core/src/main/java/com/spotify/metrics/tags/NoopTagExtractor.java
+++ b/core/src/main/java/com/spotify/metrics/tags/NoopTagExtractor.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2018 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.metrics.tags;
+
+import java.util.Map;
+
+public class NoopTagExtractor implements TagExtractor {
+
+    /**
+     * Noop does nothing.
+     *
+     * @return an unmodified map.
+     */
+    @Override
+    public Map<String, String> addTags(Map<String, String> tags) {
+        return tags;
+    }
+}

--- a/core/src/main/java/com/spotify/metrics/tags/TagExtractor.java
+++ b/core/src/main/java/com/spotify/metrics/tags/TagExtractor.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2018 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.metrics.tags;
+
+import java.util.Map;
+
+/**
+ * Extract tags to be added to and enrich Metrics.
+ */
+public interface TagExtractor {
+
+    /**
+     * Creates a new map with the extracted tags from the supplied map.
+     *
+     * @return map with extracted tags added.
+     */
+    Map<String, String> addTags(Map<String, String> tags);
+}

--- a/core/src/test/java/com/spotify/metrics/tags/EnvironmentTagExtractorTest.java
+++ b/core/src/test/java/com/spotify/metrics/tags/EnvironmentTagExtractorTest.java
@@ -1,0 +1,50 @@
+package com.spotify.metrics.tags;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+
+public class EnvironmentTagExtractorTest {
+
+    private Map<String, String> tags;
+
+    @Before
+    public void setUp() {
+        tags = ImmutableMap.of("FFWD_TAG_foo", "bar",
+            "PATH", "ignored:ignored", "FFWD_TAG_bar", "baz");
+    }
+
+    /**
+     * Test that a map containing environment variables correctly extracts and discards variables
+     * changing the tags in ffwd and retains the present ffwd tags.
+     */
+    @Test
+    public void testAddTags() {
+        final Supplier<Map<String, String>> environmentSupplier =
+            Suppliers.ofInstance(tags);
+
+        final EnvironmentTagExtractor environmentTagExtractor =
+            new EnvironmentTagExtractor(environmentSupplier);
+
+        final Map<String, String> currentMap = ImmutableMap.of("cluster", "cluster1");
+
+        final Map<String, String> out = environmentTagExtractor.addTags(currentMap);
+
+        assertEquals(ImmutableMap.of("foo", "bar", "bar", "baz", "cluster", "cluster1"), out);
+    }
+
+    /**
+     * Test that a map containing environment variables correctly extracts and discards variables
+     * changing the tags in ffwd.
+     */
+    @Test
+    public void testFilterEnvironment() {
+        final Map<String, String> out = EnvironmentTagExtractor.filterEnvironmentTags(tags);
+        assertEquals(ImmutableMap.of("foo", "bar", "bar", "baz"), out);
+    }
+}

--- a/core/src/test/java/com/spotify/metrics/tags/NoopTagExtractorTest.java
+++ b/core/src/test/java/com/spotify/metrics/tags/NoopTagExtractorTest.java
@@ -1,0 +1,24 @@
+package com.spotify.metrics.tags;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import org.junit.Test;
+
+public class NoopTagExtractorTest {
+    /**
+     * Test that no tags are extracted and added.
+     */
+    @Test
+    public void testAddTags() {
+        final NoopTagExtractor noopTagExtractor = new NoopTagExtractor();
+
+        final Map<String, String> currentMap = ImmutableMap.of("foo", "bar",
+            "bar", "baz", "cluster", "cluster1");
+
+        final Map<String, String> out = noopTagExtractor.addTags(currentMap);
+
+        assertEquals(ImmutableMap.of("foo", "bar", "bar", "baz", "cluster", "cluster1"), out);
+    }
+}


### PR DESCRIPTION
    Add support for tag extraction.
    
    This adds support for extracting tags and appending them to the
    sample(s) sent to FFWD.
    The default tag extractor does a noop and hence doesn't mutate the metrics in any way before sending.

    This change is intended to be used from Apollo's(https://github.com/spotify/apollo) metric module where we will
    extract the tags from the environment before passing them on to FFWD.


Most of the code for the `EnvironmentTagExtractor` is lifted from the [FFWD OutputManager](https://github.com/spotify/ffwd/blob/master/api/src/main/java/com/spotify/ffwd/output/OutputManager.java).

Does this seems like a reasonably approach if we wan't to source the tags from the runtime environment for Apollo and not depend on a sidecar? 