### PR TITLE
Upgrade the metrics-core and metrics-jvm libraries

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -23,12 +23,12 @@
     </dependency>
 
     <dependency>
-      <groupId>com.codahale.metrics</groupId>
+      <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-core</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>com.codahale.metrics</groupId>
+      <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-jvm</artifactId>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <metrics.version>3.0.2</metrics.version>
+    <metrics.version>4.0.3</metrics.version>
   </properties>
 
   <dependencyManagement>
@@ -77,13 +77,13 @@
       </dependency>
 
       <dependency>
-        <groupId>com.codahale.metrics</groupId>
+        <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-core</artifactId>
         <version>${metrics.version}</version>
       </dependency>
 
       <dependency>
-        <groupId>com.codahale.metrics</groupId>
+        <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-jvm</artifactId>
         <version>${metrics.version}</version>
       </dependency>


### PR DESCRIPTION
This PR fixes issue #26 that I created earlier. To sum up, the used `metrics` libraries are more than 4 years old, so I'm creating this PR to use the latest libs.