### PR TITLE
update metrics library to 4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: java
 
 jdk:
-  - openjdk7
   - oraclejdk8
 
 cache:

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.spotify.metrics</groupId>
     <artifactId>semantic-metrics-parent</artifactId>
-    <version>0.11.6-SNAPSHOT</version>
+    <version>0.12.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.spotify.metrics</groupId>
     <artifactId>semantic-metrics-parent</artifactId>
-    <version>0.12.0-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.spotify.metrics</groupId>
     <artifactId>semantic-metrics-parent</artifactId>
-    <version>0.11.6-SNAPSHOT</version>
+    <version>0.12.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -23,12 +23,12 @@
     </dependency>
 
     <dependency>
-      <groupId>com.codahale.metrics</groupId>
+      <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-core</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>com.codahale.metrics</groupId>
+      <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-jvm</artifactId>
     </dependency>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.spotify.metrics</groupId>
     <artifactId>semantic-metrics-parent</artifactId>
-    <version>0.12.0-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.spotify.metrics</groupId>
     <artifactId>semantic-metrics-parent</artifactId>
-    <version>0.11.6-SNAPSHOT</version>
+    <version>0.12.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.spotify.metrics</groupId>
     <artifactId>semantic-metrics-parent</artifactId>
-    <version>0.12.0-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/ffwd-http-reporter/pom.xml
+++ b/ffwd-http-reporter/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.spotify.metrics</groupId>
     <artifactId>semantic-metrics-parent</artifactId>
-    <version>0.11.6-SNAPSHOT</version>
+    <version>0.12.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/ffwd-http-reporter/pom.xml
+++ b/ffwd-http-reporter/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.spotify.metrics</groupId>
     <artifactId>semantic-metrics-parent</artifactId>
-    <version>0.12.0-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/ffwd-http-reporter/src/test/java/com/spotify/metrics/ffwd/FastForwardHttpReporterTest.java
+++ b/ffwd-http-reporter/src/test/java/com/spotify/metrics/ffwd/FastForwardHttpReporterTest.java
@@ -34,7 +34,7 @@ import rx.Observable;
 @RunWith(MockitoJUnitRunner.class)
 public class FastForwardHttpReporterTest {
     private static final int REPORTING_PERIOD = 50;
-    public static final long TIME = 42L;
+    private static final long TIME = 42L;
     private FastForwardHttpReporter reporter;
 
     private SemanticMetricRegistry registry;
@@ -60,7 +60,7 @@ public class FastForwardHttpReporterTest {
     }
 
     @Test
-    public void someReporting() throws Exception {
+    public void someReporting() {
         doReturn(Observable.<Void>just(null)).when(httpClient).sendBatch(any(Batch.class));
         fixedClock.setCurrentTime(TIME);
 
@@ -140,7 +140,7 @@ public class FastForwardHttpReporterTest {
 
         final ArgumentCaptor<Batch> batch = ArgumentCaptor.forClass(Batch.class);
 
-        verify(httpClient, timeout(REPORTING_PERIOD * 2 + 20).atLeast(2)).sendBatch(
+        verify(httpClient, timeout(REPORTING_PERIOD * 2 + 20).atLeastOnce()).sendBatch(
             batch.capture());
 
         for (final Batch b : batch.getAllValues()) {
@@ -173,7 +173,7 @@ public class FastForwardHttpReporterTest {
 
         final ArgumentCaptor<Batch> batch = ArgumentCaptor.forClass(Batch.class);
 
-        verify(httpClient, timeout(REPORTING_PERIOD * 2 + 20).atLeast(2)).sendBatch(
+        verify(httpClient, timeout(REPORTING_PERIOD * 2 + 20).atLeastOnce()).sendBatch(
             batch.capture());
 
         final Map<String, String> commonTags = batch.getValue().getCommonTags();

--- a/ffwd-http-reporter/src/test/java/com/spotify/metrics/ffwd/FastForwardHttpReporterTest.java
+++ b/ffwd-http-reporter/src/test/java/com/spotify/metrics/ffwd/FastForwardHttpReporterTest.java
@@ -32,7 +32,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import rx.Observable;
 
 @RunWith(MockitoJUnitRunner.class)
-public class FastForwardReporterTest {
+public class FastForwardHttpReporterTest {
     private static final int REPORTING_PERIOD = 50;
     public static final long TIME = 42L;
     private FastForwardHttpReporter reporter;

--- a/ffwd-reporter/pom.xml
+++ b/ffwd-reporter/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.spotify.metrics</groupId>
     <artifactId>semantic-metrics-parent</artifactId>
-    <version>0.11.6-SNAPSHOT</version>
+    <version>0.12.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/ffwd-reporter/pom.xml
+++ b/ffwd-reporter/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.spotify.metrics</groupId>
     <artifactId>semantic-metrics-parent</artifactId>
-    <version>0.12.0-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.spotify.metrics</groupId>
     <artifactId>semantic-metrics-parent</artifactId>
-    <version>0.11.6-SNAPSHOT</version>
+    <version>0.12.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.spotify.metrics</groupId>
     <artifactId>semantic-metrics-parent</artifactId>
-    <version>0.12.0-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <metrics.version>3.0.2</metrics.version>
+    <metrics.version>4.0.2</metrics.version>
   </properties>
 
   <dependencyManagement>
@@ -77,13 +77,13 @@
       </dependency>
 
       <dependency>
-        <groupId>com.codahale.metrics</groupId>
+        <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-core</artifactId>
         <version>${metrics.version}</version>
       </dependency>
 
       <dependency>
-        <groupId>com.codahale.metrics</groupId>
+        <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-jvm</artifactId>
         <version>${metrics.version}</version>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.spotify.metrics</groupId>
   <artifactId>semantic-metrics-parent</artifactId>
-  <version>0.11.6-SNAPSHOT</version>
+  <version>0.12.0-SNAPSHOT</version>
   <name>Semantic Metrics: Parent POM</name>
   <packaging>pom</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -193,8 +193,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.1</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.spotify.metrics</groupId>
   <artifactId>semantic-metrics-parent</artifactId>
-  <version>0.12.0-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <name>Semantic Metrics: Parent POM</name>
   <packaging>pom</packaging>
 

--- a/remote/pom.xml
+++ b/remote/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.spotify.metrics</groupId>
     <artifactId>semantic-metrics-parent</artifactId>
-    <version>0.11.6-SNAPSHOT</version>
+    <version>0.12.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/remote/pom.xml
+++ b/remote/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.spotify.metrics</groupId>
     <artifactId>semantic-metrics-parent</artifactId>
-    <version>0.12.0-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 


### PR DESCRIPTION
The 4.0 release of the metrics library (which changed groupId, from the
original author to the Dropwizard project) is the first that has support
for running under JDK9:

https://github.com/dropwizard/metrics/releases/tag/v4.0.0

When running semantic-metrics under JDK9+, a warning (at DEBUG level) is emitted each
time that FastForwardReporter emits metrics:

```
20:29:01.073 DEBUG [fast-forward-reporter-0] MetricsModule: Failed to get metrics for FileDescriptorGaugeSet
java.lang.reflect.InaccessibleObjectException: Unable to make public long com.sun.management.internal.OperatingSystemImpl.getOpenFileDescriptorCount() accessible: module jdk.management does not "opens com.sun.management.internal" to unnamed module @60438a68
        at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:340)
        at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:280)
        at java.base/java.lang.reflect.Method.checkCanSetAccessible(Method.java:198)
        at java.base/java.lang.reflect.Method.setAccessible(Method.java:192)
        at com.codahale.metrics.jvm.FileDescriptorRatioGauge.invoke(FileDescriptorRatioGauge.java:48)
        at com.codahale.metrics.jvm.FileDescriptorRatioGauge.getRatio(FileDescriptorRatioGauge.java:35)
        at com.codahale.metrics.RatioGauge.getValue(RatioGauge.java:64)
        at com.spotify.apollo.metrics.MetricsModule$1.lambda$getMetrics$0(MetricsModule.java:113)
        at com.spotify.metrics.ffwd.FastForwardReporter.reportGauge(FastForwardReporter.java:252)
        at com.spotify.metrics.ffwd.FastForwardReporter.report(FastForwardReporter.java:214)
        at com.spotify.metrics.ffwd.FastForwardReporter.report(FastForwardReporter.java:202)
        at com.spotify.metrics.ffwd.FastForwardReporter$2.run(FastForwardReporter.java:373)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
        at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305)
        at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:834)
```

The only downside of this exception is that the FileDescriptionGaugeSet
will report "NaN" values (as it has a fallback when exceptions are
caught).

v4.0 of the metrics library changed how FileDescriptorGaugeSet gets the
underlying data to not need reflection.