### PR TITLE
Add HistogramWithTtl 

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,19 @@ In addition to the tags that are specified (e.g., "what" and "endpoint" in this 
 
 Note that added custom percentiles will show up in the stat tag.
 
+### Histogram with ttl
+
+
+`HistogramWithTtl` changes the behavior of the default codahale histogram when update rate is low. If the update rate goes below a certain threshold for a certain time, all samples that have been received during that time are used instead of the random sample that is used in the default histogram implementation. When update rates are above the threshold, the default implementation is used.
+
+**What problem does it solve?**
+
+The default histogram implementation uses a random sampling algorithm with exponentially decaying probabilities over time. This works well if update rates are approximately 10 requests per second or above. When rates go below that, the metrics, especially p99 and above tends to flatline because the values are not replaced often enough. We solve this by using a different implementation whenever the update rate goes below 10 RPS. This gives much more dynamic percentile measurements during low update rates. When update rates go above the threshold we switch to the default implementation.
+
+This was authored by Johan Buratti. 
+
+
+
 ## Timer
 A timer measures both the rate that a particular piece of code is called and
 the distribution of its duration.

--- a/core/src/main/java/com/spotify/metrics/core/HistogramWithTtl.java
+++ b/core/src/main/java/com/spotify/metrics/core/HistogramWithTtl.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2018 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.metrics.core;
+
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Reservoir;
+
+public class HistogramWithTtl extends Histogram {
+    public HistogramWithTtl() {
+        super(new ReservoirWithTtl());
+    }
+
+    public HistogramWithTtl(final Reservoir delegate, final int ttlSeconds, final int minimumRate) {
+        super(new ReservoirWithTtl(delegate, ttlSeconds, minimumRate));
+    }
+}

--- a/core/src/main/java/com/spotify/metrics/core/ReservoirWithTtl.java
+++ b/core/src/main/java/com/spotify/metrics/core/ReservoirWithTtl.java
@@ -88,6 +88,10 @@ public class ReservoirWithTtl implements Reservoir {
         this(new ExponentiallyDecayingReservoir(), DEFAULT_TTL_SECONDS, DEFAULT_MINIMUM_RATE);
     }
 
+    public ReservoirWithTtl(final int ttlSeconds) {
+        this(new ExponentiallyDecayingReservoir(), ttlSeconds, DEFAULT_MINIMUM_RATE);
+    }
+
     public ReservoirWithTtl(final Reservoir delegate, final int ttlSeconds, final int minimumRate) {
         this(delegate, ttlSeconds, minimumRate, Instant::now);
     }

--- a/core/src/main/java/com/spotify/metrics/core/ReservoirWithTtl.java
+++ b/core/src/main/java/com/spotify/metrics/core/ReservoirWithTtl.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2018 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.metrics.core;
+
+import static java.util.stream.Collectors.toList;
+
+import com.codahale.metrics.ExponentiallyDecayingReservoir;
+import com.codahale.metrics.Reservoir;
+import com.codahale.metrics.Snapshot;
+import com.google.common.collect.EvictingQueue;
+
+import java.lang.reflect.Constructor;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+public class ReservoirWithTtl implements Reservoir {
+    private class ValueAndTimestamp {
+        public long value;
+        public Instant timestamp;
+
+        public ValueAndTimestamp(final long value, final Instant timestamp) {
+            this.value = value;
+            this.timestamp = timestamp;
+        }
+    }
+
+    private static final int DEFAULT_TTL_SECONDS = (int) TimeUnit.MINUTES.toSeconds(5);
+
+    private static final int DEFAULT_MINIMUM_RATE = 10;
+
+    private static Constructor SNAPSHOT_CONSTRUCTOR;
+
+    private final int ttlSeconds;
+
+    private final int bufferSize;
+
+    private final Reservoir delegate;
+
+    private final EvictingQueue<ValueAndTimestamp> valueBuffer;
+
+    private final Supplier<Instant> now;
+
+    static {
+        // There is a breaking API change between metrics-core 3.1 and 3.2 where
+        // com.codahale.metrics.Snapshot becomes abstract and is replaced by UniformSnapshot. There are
+        // more breaking changes between the two versions (bumbing breaks hermes-java for instance).
+        // On the other hand, newer versions of the datastax drivers use the newer version. This means
+        // that to not force anyone to make a lot of changes to be able to use this library, we need to
+        // support both versions. The below code is the most sane way we have found to do that: We find
+        // one class out of the two candidates that is possible to construct and save a reference to
+        // its constructor.
+        try {
+            SNAPSHOT_CONSTRUCTOR = Class.forName("com.codahale.metrics.Snapshot")
+                                        .getConstructor(Collection.class);
+        } catch (final ClassNotFoundException | NoSuchMethodException e) {
+            try {
+                SNAPSHOT_CONSTRUCTOR = Class.forName("com.codahale.metrics.UniformSnapshot")
+                                            .getConstructor(Collection.class);
+            } catch (final ClassNotFoundException | NoSuchMethodException e2) {
+                throw new RuntimeException(e2);
+            }
+        }
+    }
+
+    public ReservoirWithTtl() {
+        this(new ExponentiallyDecayingReservoir(), DEFAULT_TTL_SECONDS, DEFAULT_MINIMUM_RATE);
+    }
+
+    public ReservoirWithTtl(final Reservoir delegate, final int ttlSeconds, final int minimumRate) {
+        this(delegate, ttlSeconds, minimumRate, Instant::now);
+    }
+
+    public ReservoirWithTtl(
+        final Reservoir delegate,
+        final int ttlSeconds,
+        final int minimumRate,
+        final Supplier<Instant> now) {
+        this.delegate = delegate;
+        this.now = now;
+        this.ttlSeconds = ttlSeconds;
+        this.bufferSize = ttlSeconds * minimumRate;
+        this.valueBuffer = EvictingQueue.create(bufferSize);
+    }
+
+    @Override
+    public int size() {
+        synchronized (this) {
+            purgeOld();
+            if (useInternalBuffer()) {
+                return valueBuffer.size();
+            }
+        }
+
+        return delegate.size();
+    }
+
+    @Override
+    public void update(final long value) {
+        synchronized (this) {
+            valueBuffer.add(new ValueAndTimestamp(value, now.get()));
+        }
+
+        delegate.update(value);
+    }
+
+    @Override
+    public Snapshot getSnapshot() {
+        synchronized (this) {
+            purgeOld();
+            if (useInternalBuffer()) {
+                return getInternalSnapshot();
+            }
+        }
+
+        return delegate.getSnapshot();
+    }
+
+    private boolean useInternalBuffer() {
+        return valueBuffer.size() < bufferSize;
+    }
+
+    private void purgeOld() {
+        final Instant cutoffTime = now.get().minusSeconds(ttlSeconds);
+        while (!valueBuffer.isEmpty() && valueBuffer.peek().timestamp.isBefore(cutoffTime)) {
+            valueBuffer.remove();
+        }
+    }
+
+    private Snapshot getInternalSnapshot() {
+        try {
+            // See comment at static initializer why we need to use constructor reference
+            return (Snapshot) SNAPSHOT_CONSTRUCTOR.newInstance(
+                valueBuffer.stream().map(v -> v.value).collect(toList()));
+        } catch (final Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/core/src/main/java/com/spotify/metrics/core/SemanticMetricRegistry.java
+++ b/core/src/main/java/com/spotify/metrics/core/SemanticMetricRegistry.java
@@ -74,6 +74,12 @@ public class SemanticMetricRegistry implements SemanticMetricSet {
         this(new ConcurrentHashMap<MetricId, Metric>(), () -> new ExponentiallyDecayingReservoir());
     }
 
+    public SemanticMetricRegistry(final Supplier<Reservoir> defaultReservoirSupplier) {
+        this.metrics = new ConcurrentHashMap<MetricId, Metric>();
+        this.listeners = new CopyOnWriteArrayList<SemanticMetricRegistryListener>();
+        this.defaultReservoirSupplier = defaultReservoirSupplier;
+    }
+
     public SemanticMetricRegistry(
         final ConcurrentMap<MetricId, Metric> metrics,
         final Supplier<Reservoir> defaultReservoirSupplier

--- a/core/src/test/java/com/spotify/metrics/core/ReservoirWithTtlTest.java
+++ b/core/src/test/java/com/spotify/metrics/core/ReservoirWithTtlTest.java
@@ -1,0 +1,87 @@
+package com.spotify.metrics.core;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import com.codahale.metrics.Reservoir;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ReservoirWithTtlTest {
+    @Mock private Reservoir delegateMock;
+
+    private Instant now = Instant.EPOCH;
+
+    private final int ttlSeconds = 10;
+    private final int minimumRate = 10;
+    private final int bufferSize = ttlSeconds * minimumRate;
+
+    private ReservoirWithTtl reservoir;
+
+    @Before
+    public void before() {
+        reservoir = new ReservoirWithTtl(delegateMock, ttlSeconds, minimumRate, () -> now);
+    }
+
+    @Test
+    public void testInternalBufferIsUsedWhenRequestRateIsLow() {
+        for (int i = 0; i < bufferSize - 1; i++) {
+            reservoir.update(i);
+            verify(delegateMock).update(i);
+        }
+
+        assertEquals(bufferSize - 1, reservoir.size());
+        assertEquals(bufferSize - 1, reservoir.getSnapshot().size());
+
+        verifyNoMoreInteractions(delegateMock);
+    }
+
+    @Test
+    public void testDelegateIsUsedWhenRequestRateHigh() {
+        for (int i = 0; i < bufferSize; i++) {
+            reservoir.update(i);
+            verify(delegateMock).update(i);
+        }
+
+        reservoir.size();
+        verify(delegateMock).size();
+
+        reservoir.getSnapshot();
+        verify(delegateMock).getSnapshot();
+
+        verifyNoMoreInteractions(delegateMock);
+    }
+
+    @Test
+    public void testValuesInBufferExpires() {
+        for (int i = 0; i < 10; i++) {
+            reservoir.update(i);
+        }
+        assertEquals(10, reservoir.size());
+
+        now = now.plus(1, ChronoUnit.SECONDS);
+
+        for (int i = 0; i < 5; i++) {
+            reservoir.update(i);
+        }
+        assertEquals(15, reservoir.size());
+
+        now = now.plus(9, ChronoUnit.SECONDS);
+        assertEquals(15, reservoir.size());
+        assertArrayEquals(
+            new long[] {0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 6, 7, 8, 9},
+            reservoir.getSnapshot().getValues());
+
+        now = now.plus(1, ChronoUnit.SECONDS);
+        assertEquals(5, reservoir.size());
+        assertArrayEquals(new long[] {0, 1, 2, 3, 4}, reservoir.getSnapshot().getValues());
+    }
+}


### PR DESCRIPTION
This was authored by Johan Buratti at Spotify and is being included in this library to be used in other Spotify opensource projects like Apollo.

`HistogramWithTtl` changes the behavior of the default codahale histogram when update rate is low. If the update rate goes below a certain threshold for a certain time, all samples that have been received during that time are used instead of the random sample that is used in the default histogram implementation. When update rates are above the threshold, the default implementation is used.

The default histogram implementation uses a random sampling algorithm with exponentially decaying probabilities over time. This works well if update rates are approximately 10 requests per second or above. When rates go below that, the metrics, especially p99 and above tends to flatline because the values are not replaced often enough. We solve this by using a different implementation whenever the update rate goes below 10 RPS. This gives much more dynamic percentile measurements during low update rates. When update rates go above the threshold we switch to the default implementation.


@jsferrei 