### PR TITLE
Adding BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
     <module>examples</module>
     <module>guava</module>
     <module>remote</module>
+    <module>semantic-metrics-bom</module>
   </modules>
 
   <properties>

--- a/semantic-metrics-bom/pom.xml
+++ b/semantic-metrics-bom/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>semantic-metrics-bom</artifactId>
+  <name>Semantic Metrics: Bill Of Materials</name>
+
+  <parent>
+    <groupId>com.spotify.metrics</groupId>
+    <artifactId>semantic-metrics-parent</artifactId>
+    <version>1.0.3-SNAPSHOT</version>
+    <relativePath>..</relativePath>
+  </parent>
+
+  <description>
+    Semantic Metrics: Bill Of Materials
+  </description>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.spotify.metrics</groupId>
+        <artifactId>semantic-metrics-api</artifactId>
+        <version>${project.parent.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.spotify.metrics</groupId>
+        <artifactId>semantic-metrics-core</artifactId>
+        <version>${project.parent.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.spotify.metrics</groupId>
+        <artifactId>semantic-metrics-ffwd-reporter</artifactId>
+        <version>${project.parent.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.spotify.metrics</groupId>
+        <artifactId>semantic-metrics-ffwd-http-reporter</artifactId>
+        <version>${project.parent.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.spotify.metrics</groupId>
+        <artifactId>semantic-metrics-guava</artifactId>
+        <version>${project.parent.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.spotify.metrics</groupId>
+        <artifactId>semantic-metrics-remote</artifactId>
+        <version>${project.parent.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+</project>


### PR DESCRIPTION
Usually at least 2 modules from semantic metrics are used, which requires dependant projects to pin versions of multiple artifacts in dependencyManagement section. Importing BOM simplifies version pinning across multiple artifacts.