### PR TITLE
Remove javadoc plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,3 @@ cache:
 
 script:
   - mvn -D environment=test verify
-  # make sure javadocs are ok too
-  - mvn -P release javadoc:javadoc

--- a/pom.xml
+++ b/pom.xml
@@ -152,13 +152,6 @@
             </configuration>
           </plugin>
           <plugin>
-            <artifactId>maven-javadoc-plugin</artifactId>
-            <version>3.0.1</version>
-            <configuration>
-              <doclint>none</doclint>
-            </configuration>
-          </plugin>
-          <plugin>
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>nexus-staging-maven-plugin</artifactId>
             <version>1.6.3</version>


### PR DESCRIPTION
Currently the generated javadocs are not published anywhere for consumption.