### PR TITLE
Switch to openjdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: java
 
 jdk:
   - openjdk8
-  - openjdk10
   - openjdk11
   
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-  - oraclejdk8
+  - openjdk8
   - openjdk10
   - openjdk11
   


### PR DESCRIPTION
Following travis error is being thrown...

```
install-jdk.sh 2019-07-17
Expected feature release number in range of 9 to 14, but got: 8
```