### PR TITLE
adjust the warning about MetricId being expensive / MetricIdCache

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,12 @@ See and run [examples](examples/src/main/java/com/spotify/metrics/example).
 
 # Considerations
 
-#### ```MetricId``` is expensive to create and modify
+#### `MetricIdCache`
 
 If you find yourself in a situation where you create many instances of this
-class (i.e. when reporting metrics), make use of
-[MetricIdCache](api/src/main/java/com/spotify/metrics/core/MetricIdCache.java)
+class (i.e. when reporting metrics) and profiling/benchmarks show a significant 
+amount of time spent constructing MetricId instances, considering making use of
+a [MetricIdCache](api/src/main/java/com/spotify/metrics/core/MetricIdCache.java)
 
 The following is an example integrating with Guava.
 


### PR DESCRIPTION
Some number of people who read this end up reaching for the extra complexity of a MetricIdCache before even knowing that their application is spending considerable time simply constructing/copying MetricId instances. This change softens the warning and removes the assertion that "MetricId is expensive", which doesn't offer any quantification.