### PR TITLE
ffwd reporter: do not translate null gauge value to 0

### DIFF
--- a/ffwd-reporter/src/main/java/com/spotify/metrics/ffwd/FastForwardReporter.java
+++ b/ffwd-reporter/src/main/java/com/spotify/metrics/ffwd/FastForwardReporter.java
@@ -238,10 +238,6 @@ public class FastForwardReporter implements AutoCloseable {
     private void reportGauge(
         MetricId key, @SuppressWarnings("rawtypes") Gauge value
     ) {
-        if (value == null) {
-            return;
-        }
-
         key = MetricId.join(prefix, key);
 
         final Metric m = FastForward
@@ -249,7 +245,12 @@ public class FastForwardReporter implements AutoCloseable {
             .attributes(key.getTags())
             .attribute(METRIC_TYPE, "gauge");
 
-        send(m.value(convert(value.getValue())));
+        Object gaugeValue = value.getValue();
+        if (gaugeValue == null) {
+            return;
+        }
+
+        send(m.value(convert(gaugeValue)));
     }
 
     private double convert(Object value) {


### PR DESCRIPTION
For reference, the upstream `GraphiteReporter` skips null gauge values.

https://github.com/dropwizard/metrics/blob/21fc51b6e52c76d82c2c97ac73cb3db5dc2a760d/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java#L367