### PR TITLE
Sonatype OSS requirements to publish Maven artifacts on Maven Central…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,9 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <metrics.version>4.0.2</metrics.version>
     <doclint>none</doclint>
+    <!-- This plugin intentionally does not deliver javadoc. -->
+    <!-- Java 11 javadoc command fails from maven. -->
+    <maven.javadoc.skip>true</maven.javadoc.skip>
   </properties>
 
   <dependencyManagement>
@@ -150,7 +153,6 @@
             <version>2.5.3</version>
             <configuration>
               <tagNameFormat>@{project.version}</tagNameFormat>
-              <arguments>-Dmaven.javadoc.skip=true</arguments>
             </configuration>
           </plugin>
           <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <metrics.version>4.0.2</metrics.version>
+    <doclint>none</doclint>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -208,6 +208,18 @@
         </executions>
       </plugin>
       <plugin>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>2.9.1</version>
+        <executions>
+          <execution>
+            <id>attach-javadoc</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <version>3.1.0</version>


### PR DESCRIPTION
…, all the Maven modules with a JAR packaging must provide both -sources and -javadoc JAR files.

https://stackoverflow.com/questions/4023373/source-and-javadoc-jar-generation

https://vzurczak.wordpress.com/2014/08/01/generate-an-empty-javadoc-jar-file/