### PR TITLE
Make tests deterministic

### DIFF
--- a/ffwd-http-reporter/pom.xml
+++ b/ffwd-http-reporter/pom.xml
@@ -54,5 +54,11 @@
       <version>1.0.13</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jmock</groupId>
+      <artifactId>jmock</artifactId>
+      <version>2.12.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/ffwd-reporter/pom.xml
+++ b/ffwd-reporter/pom.xml
@@ -55,5 +55,11 @@
       <version>1.0.13</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jmock</groupId>
+      <artifactId>jmock</artifactId>
+      <version>2.12.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
If the tests are using Thread.sleep and Mockito.timeout, the
tests can become flaky if the system that is running the tests
is temporarily slow.

By replacing that with a deterministic executor, the tests are both
more robust and faster to execute