### PR TITLE
Fix null pointer exception

### DIFF
--- a/api/src/main/java/com/spotify/metrics/core/MetricId.java
+++ b/api/src/main/java/com/spotify/metrics/core/MetricId.java
@@ -413,10 +413,13 @@ public class MetricId implements Comparable<MetricId> {
                 return k;
             }
 
-            final int v = l.getValue().compareTo(r.getValue());
+            if (l.getValue() != null && r.getValue() != null) {
 
-            if (v != 0) {
-                return v;
+                final int v = l.getValue().compareTo(r.getValue());
+
+                if (v != 0) {
+                    return v;
+                }
             }
         }
 

--- a/api/src/test/java/com/spotify/metrics/core/MetricIdTest.java
+++ b/api/src/test/java/com/spotify/metrics/core/MetricIdTest.java
@@ -1,17 +1,17 @@
 package com.spotify.metrics.core;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class MetricIdTest {
@@ -20,7 +20,7 @@ public class MetricIdTest {
     @Test
     public void testEmpty() throws Exception {
         assertEquals(MetricId.EMPTY_TAGS, MetricId.EMPTY.getTags());
-        assertEquals(null, MetricId.EMPTY.getKey());
+        assertNull(MetricId.EMPTY.getKey());
         assertEquals(MetricId.EMPTY_TAGS, new MetricId().getTags());
 
         assertEquals(new MetricId(), MetricId.EMPTY);
@@ -88,12 +88,18 @@ public class MetricIdTest {
     public void testCompareTo() {
         final MetricId a = MetricId.EMPTY.tagged("foo", "bar");
         final MetricId b = MetricId.EMPTY.tagged("foo", "baz");
+        final MetricId c = MetricId.EMPTY.tagged("foo", null);
 
         assertTrue(a.compareTo(b) != 0);
         assertTrue(b.compareTo(a) != 0);
-        assertTrue(b.compareTo(b) == 0);
+        assertTrue(c.compareTo(a) != 0);
+        assertTrue(a.compareTo(c) != 0);
+        assertEquals(0, b.compareTo(b));
+        assertEquals(0, c.compareTo(c));
         assertTrue(b.resolve("key").compareTo(b) != 0);
         assertTrue(b.compareTo(b.resolve("key")) != 0);
+        assertTrue(c.resolve("key").compareTo(c) != 0);
+        assertTrue(c.compareTo(c.resolve("key")) != 0);
     }
 
     @Test
@@ -102,16 +108,16 @@ public class MetricIdTest {
       final MetricId b = MetricId.EMPTY.tagged("a", "1", "b", "3");
       final MetricId c = MetricId.EMPTY.tagged("a", "1", "b", "3");
 
-      assertTrue(a.compareTo(a) == 0);
+      assertEquals(0, a.compareTo(a));
       assertTrue(a.compareTo(b) != 0);
-      assertTrue(b.compareTo(b) == 0);
+      assertEquals(0, b.compareTo(b));
       assertTrue(b.compareTo(a) != 0);
 
-      assertTrue(b.compareTo(c) == 0);
-      assertTrue(c.compareTo(b) == 0);
+      assertEquals(0, b.compareTo(c));
+      assertEquals(0, c.compareTo(b));
     }
 
-  @Test
+    @Test
     public void testEqualsAndHashCode() {
         // a map which always returns the same hashCode, but is equal to nothing.
         final SortedMap<String, String> tags = new TreeMap<String, String>() {


### PR DESCRIPTION
Reported earlier today, running v 1.0.2:
```
ERROR c.s.m.f.FastForwardReporter [fast-forward-reporter-0] Error when trying to report metric java.lang.NullPointerException
        at com.spotify.metrics.core.MetricId.compareTags(MetricId.java:350)
        at com.spotify.metrics.core.MetricId.compareTo(MetricId.java:278)
        at com.spotify.metrics.core.MetricId.compareTo(MetricId.java:45)
        at java.util.TreeMap.put(TreeMap.java:568)
        at com.spotify.metrics.core.SemanticMetricRegistry.getMetrics(SemanticMetricRegistry.java:417)
        at com.spotify.metrics.core.SemanticMetricRegistry.getMeters(SemanticMetricRegistry.java:309)
        at com.spotify.metrics.ffwd.FastForwardReporter.report(FastForwardReporter.java:183)
        at com.spotify.metrics.ffwd.FastForwardReporter$2.run(FastForwardReporter.java:350)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
```

This should solve the issue, still trying to work out how to replicate it in a test. 