### PR TITLE
Use a lock-free version of ExponentiallyDecayingReservoir to reduce contention

### DIFF
--- a/core/src/main/java/com/spotify/metrics/core/LockFreeExponentiallyDecayingReservoir.java
+++ b/core/src/main/java/com/spotify/metrics/core/LockFreeExponentiallyDecayingReservoir.java
@@ -1,0 +1,217 @@
+package com.spotify.metrics.core;
+
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.lang.Math.exp;
+import static java.lang.Math.min;
+
+import com.codahale.metrics.Clock;
+import com.codahale.metrics.Reservoir;
+import com.codahale.metrics.Snapshot;
+import com.codahale.metrics.WeightedSnapshot;
+import com.codahale.metrics.WeightedSnapshot.WeightedSample;
+
+// TODO: replace this with the default in com.codahale.metrics once it's been released
+
+/**
+ * An exponentially-decaying random reservoir of {@code long}s. Uses Cormode et al's
+ * forward-decaying priority reservoir sampling method to produce a statistically representative
+ * sampling reservoir, exponentially biased towards newer entries.
+ *
+ * @see <a href="http://dimacs.rutgers.edu/~graham/pubs/papers/fwddecay.pdf">
+ * Cormode et al. Forward Decay: A Practical Time Decay Model for Streaming Systems. ICDE '09:
+ * Proceedings of the 2009 IEEE International Conference on Data Engineering (2009)</a>
+ */
+
+class LockFreeExponentiallyDecayingReservoir implements Reservoir {
+    private static final int DEFAULT_SIZE = 1028;
+    private static final double DEFAULT_ALPHA = 0.015;
+    private static final long RESCALE_THRESHOLD = TimeUnit.HOURS.toNanos(1);
+
+    private final double alpha;
+    private final int size;
+    private final AtomicLong nextScaleTime;
+    private final Clock clock;
+
+    private volatile State writerState;
+    private volatile State snapshotState;
+
+
+    /**
+     * Creates a new {@link LockFreeExponentiallyDecayingReservoir} of 1028 elements, which offers a 99.9%
+     * confidence level with a 5% margin of error assuming a normal distribution, and an alpha
+     * factor of 0.015, which heavily biases the reservoir to the past 5 minutes of measurements.
+     */
+    public LockFreeExponentiallyDecayingReservoir() {
+        this(DEFAULT_SIZE, DEFAULT_ALPHA);
+    }
+
+    /**
+     * Creates a new {@link LockFreeExponentiallyDecayingReservoir}.
+     *
+     * @param size  the number of samples to keep in the sampling reservoir
+     * @param alpha the exponential decay factor; the higher this is, the more biased the reservoir
+     *              will be towards newer values
+     */
+    public LockFreeExponentiallyDecayingReservoir(int size, double alpha) {
+        this(size, alpha, Clock.defaultClock());
+    }
+
+    /**
+     * Creates a new {@link LockFreeExponentiallyDecayingReservoir}.
+     *
+     * @param size  the number of samples to keep in the sampling reservoir
+     * @param alpha the exponential decay factor; the higher this is, the more biased the reservoir
+     *              will be towards newer values
+     * @param clock the clock used to timestamp samples and track rescaling
+     */
+    public LockFreeExponentiallyDecayingReservoir(int size, double alpha, Clock clock) {
+        this.alpha = alpha;
+        this.size = size;
+        this.clock = clock;
+        this.writerState = new State(currentTimeInSeconds());
+        this.snapshotState = writerState;
+        this.nextScaleTime = new AtomicLong(clock.getTick() + RESCALE_THRESHOLD);
+    }
+
+    @Override
+    public int size() {
+        return (int) min(size, writerState.count.get());
+    }
+
+    @Override
+    public void update(long value) {
+        update(value, currentTimeInSeconds());
+    }
+
+    /**
+     * Adds an old value with a fixed timestamp to the reservoir.
+     *
+     * @param value     the value to be added
+     * @param timestamp the epoch timestamp of {@code value} in seconds
+     */
+    public void update(long value, long timestamp) {
+        rescaleIfNeeded();
+        final State localState = this.writerState;
+        localState.update(value, timestamp);
+        final State newLocalState = this.writerState;
+        if (localState != newLocalState) {
+            newLocalState.backfill(localState);
+        }
+    }
+
+    private void rescaleIfNeeded() {
+        final long now = clock.getTick();
+        final long next = nextScaleTime.get();
+        if (now >= next) {
+            rescale(now, next);
+        }
+    }
+
+    @Override
+    public Snapshot getSnapshot() {
+        rescaleIfNeeded();
+        return new WeightedSnapshot(snapshotState.values.get().values());
+    }
+
+    private long currentTimeInSeconds() {
+        return TimeUnit.MILLISECONDS.toSeconds(clock.getTime());
+    }
+
+    private double weight(long t) {
+        return exp(alpha * t);
+    }
+
+    /* "A common feature of the above techniques—indeed, the key technique that
+     * allows us to track the decayed weights efficiently—is that they maintain
+     * counts and other quantities based on g(ti − L), and only scale by g(t − L)
+     * at query time. But while g(ti −L)/g(t−L) is guaranteed to lie between zero
+     * and one, the intermediate values of g(ti − L) could become very large. For
+     * polynomial functions, these values should not grow too large, and should be
+     * effectively represented in practice by floating point values without loss of
+     * precision. For exponential functions, these values could grow quite large as
+     * new values of (ti − L) become large, and potentially exceed the capacity of
+     * common floating point types. However, since the values stored by the
+     * algorithms are linear combinations of g values (scaled sums), they can be
+     * rescaled relative to a new landmark. That is, by the analysis of exponential
+     * decay in Section III-A, the choice of L does not affect the final result. We
+     * can therefore multiply each value based on L by a factor of exp(−α(L′ − L)),
+     * and obtain the correct value as if we had instead computed relative to a new
+     * landmark L′ (and then use this new L′ at query time). This can be done with
+     * a linear pass over whatever data structure is being used."
+     */
+    private void rescale(long now, long next) {
+        if (nextScaleTime.compareAndSet(next, now + RESCALE_THRESHOLD)) {
+            State oldState = this.writerState;
+            State newState = new State(currentTimeInSeconds());
+
+            this.writerState = newState;
+            // Snapshot won't see new values until the backfill completes
+            newState.backfill(oldState);
+
+            this.snapshotState = newState;
+        }
+    }
+
+    private class State {
+
+        private final AtomicReference<ConcurrentSkipListMap<Double, WeightedSample>> values =
+                new AtomicReference<>(new ConcurrentSkipListMap<>());
+
+        private final long startTime;
+        private final AtomicLong count = new AtomicLong();
+
+        private State(long startTime) {
+            this.startTime = startTime;
+        }
+
+        private void backfill(State previous) {
+            final double scalingFactor = exp(-alpha * (startTime - previous.startTime));
+
+            final ConcurrentSkipListMap<Double, WeightedSample> oldValues = previous.values.getAndSet(new ConcurrentSkipListMap<>());
+            previous.count.addAndGet(-oldValues.size());
+
+            if (Double.compare(scalingFactor, 0) == 0) {
+                return;
+            }
+
+            // Slightly racy - calls to update() could add values while we iterate over it
+            // but it should not affect the overall statistical correctness
+            for (final WeightedSample sample : oldValues.values()) {
+                final double newWeight = sample.weight * scalingFactor;
+                if (Double.compare(newWeight, 0) != 0) {
+                    update(new WeightedSample(sample.value, newWeight), newWeight);
+                }
+            }
+
+        }
+
+        private void update(long value, long timestamp) {
+            final double itemWeight = weight(timestamp - startTime);
+            final WeightedSample sample = new WeightedSample(value, itemWeight);
+            final double priority = itemWeight / ThreadLocalRandom.current().nextDouble();
+
+            update(sample, priority);
+        }
+
+        private void update(WeightedSample sample, double priority) {
+            ConcurrentSkipListMap<Double, WeightedSample> map = values.get();
+            final long newCount = count.incrementAndGet();
+            if (newCount <= size) {
+                map.put(priority, sample);
+            } else {
+                Double first = map.firstKey();
+                if (first < priority && map.putIfAbsent(priority, sample) == null) {
+                    // ensure we always remove an item
+                    while (map.remove(first) == null) {
+                        first = map.firstKey();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/core/src/main/java/com/spotify/metrics/core/ReservoirWithTtl.java
+++ b/core/src/main/java/com/spotify/metrics/core/ReservoirWithTtl.java
@@ -21,7 +21,6 @@
 
 package com.spotify.metrics.core;
 
-import com.codahale.metrics.ExponentiallyDecayingReservoir;
 import com.codahale.metrics.Reservoir;
 import com.codahale.metrics.Snapshot;
 
@@ -85,11 +84,12 @@ public class ReservoirWithTtl implements Reservoir {
     }
 
     public ReservoirWithTtl() {
-        this(new ExponentiallyDecayingReservoir(), DEFAULT_TTL_SECONDS, DEFAULT_MINIMUM_RATE);
+        this(new LockFreeExponentiallyDecayingReservoir(),
+             DEFAULT_TTL_SECONDS, DEFAULT_MINIMUM_RATE);
     }
 
     public ReservoirWithTtl(final int ttlSeconds) {
-        this(new ExponentiallyDecayingReservoir(), ttlSeconds, DEFAULT_MINIMUM_RATE);
+        this(new LockFreeExponentiallyDecayingReservoir(), ttlSeconds, DEFAULT_MINIMUM_RATE);
     }
 
     public ReservoirWithTtl(final Reservoir delegate, final int ttlSeconds, final int minimumRate) {

--- a/core/src/main/java/com/spotify/metrics/core/SemanticMetricBuilder.java
+++ b/core/src/main/java/com/spotify/metrics/core/SemanticMetricBuilder.java
@@ -22,7 +22,6 @@
 package com.spotify.metrics.core;
 
 import com.codahale.metrics.Counter;
-import com.codahale.metrics.ExponentiallyDecayingReservoir;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.Metric;
@@ -45,7 +44,7 @@ public interface SemanticMetricBuilder<T extends Metric> {
     };
 
     SemanticMetricBuilder<Histogram> HISTOGRAMS = SemanticMetricBuilderFactory
-        .histogramWithReservoir(() -> new ExponentiallyDecayingReservoir());
+        .histogramWithReservoir(() -> new LockFreeExponentiallyDecayingReservoir());
 
     SemanticMetricBuilder<Meter> METERS = new SemanticMetricBuilder<Meter>() {
         @Override
@@ -60,7 +59,7 @@ public interface SemanticMetricBuilder<T extends Metric> {
     };
 
     SemanticMetricBuilder<Timer> TIMERS = SemanticMetricBuilderFactory
-        .timerWithReservoir(() -> new ExponentiallyDecayingReservoir());
+        .timerWithReservoir(() -> new LockFreeExponentiallyDecayingReservoir());
 
     SemanticMetricBuilder<DerivingMeter> DERIVING_METERS =
         new SemanticMetricBuilder<DerivingMeter>() {

--- a/core/src/main/java/com/spotify/metrics/core/SemanticMetricRegistry.java
+++ b/core/src/main/java/com/spotify/metrics/core/SemanticMetricRegistry.java
@@ -31,7 +31,6 @@
 package com.spotify.metrics.core;
 
 import com.codahale.metrics.Counter;
-import com.codahale.metrics.ExponentiallyDecayingReservoir;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
@@ -63,7 +62,7 @@ public class SemanticMetricRegistry implements SemanticMetricSet {
      * Creates a new {@link SemanticMetricRegistry}.
      */
     public SemanticMetricRegistry(final ConcurrentMap<MetricId, Metric> metrics) {
-        this(metrics, () -> new ExponentiallyDecayingReservoir());
+        this(metrics, () -> new LockFreeExponentiallyDecayingReservoir());
     }
 
     /**
@@ -72,7 +71,8 @@ public class SemanticMetricRegistry implements SemanticMetricSet {
     public SemanticMetricRegistry() {
         // This is only for backward compatibility purpose. After removing the "buildMap" method
         // we should call this(new ConcurrentHashMap<MetricId, Metric>()) instead.
-        this(new ConcurrentHashMap<MetricId, Metric>(), () -> new ExponentiallyDecayingReservoir());
+        this(new ConcurrentHashMap<MetricId, Metric>(),
+            () -> new LockFreeExponentiallyDecayingReservoir());
     }
 
     public SemanticMetricRegistry(final Supplier<Reservoir> defaultReservoirSupplier) {

--- a/core/src/test/java/com/spotify/metrics/core/SemanticMetricBuilderFactoryTest.java
+++ b/core/src/test/java/com/spotify/metrics/core/SemanticMetricBuilderFactoryTest.java
@@ -14,7 +14,7 @@ public class SemanticMetricBuilderFactoryTest {
     public void timerWithReservoir() throws Exception {
         final SemanticMetricBuilder<Timer> result =
             SemanticMetricBuilderFactory.timerWithReservoir(() -> {
-                return new ExponentiallyDecayingReservoir();
+                return new LockFreeExponentiallyDecayingReservoir();
             });
         assert Timer.class.isInstance(result.newMetric());
     }
@@ -23,7 +23,7 @@ public class SemanticMetricBuilderFactoryTest {
     public void histogramWithReservoir() throws Exception {
         final SemanticMetricBuilder<Histogram> result =
             SemanticMetricBuilderFactory.histogramWithReservoir(() -> {
-                return new ExponentiallyDecayingReservoir();
+                return new LockFreeExponentiallyDecayingReservoir();
             });
         assert Histogram.class.isInstance(result.newMetric());
     }

--- a/pom.xml
+++ b/pom.xml
@@ -235,6 +235,7 @@
           <failsOnError>true</failsOnError>
           <maxAllowedViolations>0</maxAllowedViolations>
           <propertyExpansion>basedir=${user.dir}</propertyExpansion>
+          <excludes>**/LockFreeExponentiallyDecayingReservoir.java</excludes>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
Revert this change once you upgrade the codahale metrics dependency to a version
that already includes this.