### PR TITLE
Make count decrease align with increase.

### DIFF
--- a/core/src/main/java/com/spotify/metrics/core/LockFreeExponentiallyDecayingReservoir.java
+++ b/core/src/main/java/com/spotify/metrics/core/LockFreeExponentiallyDecayingReservoir.java
@@ -173,7 +173,7 @@ class LockFreeExponentiallyDecayingReservoir implements Reservoir {
             final double scalingFactor = exp(-alpha * (startTime - previous.startTime));
 
             final ConcurrentSkipListMap<Double, WeightedSample> oldValues = previous.values.getAndSet(new ConcurrentSkipListMap<>());
-            previous.count.addAndGet(-oldValues.size());
+            previous.count.set(0);
 
             if (Double.compare(scalingFactor, 0) == 0) {
                 return;


### PR DESCRIPTION
The `State.update` always increase `count` regardless if it is at full `size` or not. Which means it can grow larger than `size`. So when `backfill` replaces the values with an empty `ConcurrentSkipListMap` and only decrement by `-oldValues.size()`, it means count can still be larger than size while map is empty. Which can cause a NoSuchElementException at a concurrent `update` call.

I would have felt much more confident about submitting this PR if there had been unit tests for `LockFreeExponentiallyDecayingReservoir`. Now I have to trust the vigilant eyes of the reviewers. _I might have gotten this all wrong._ But for sure I have had occasional NoSuchElementException on line 207 in most of my backend projects the past few weeks. It has also been mentioned in https://github.com/spotify/semantic-metrics/issues/85

Still after this change, I feel that there are some race conditions that can occur, as it is impossible to guarantee that `count` and `values` are both reset together atomically, so an update might look at the old instance of the values map and the already reset count. That could lead to the reset counter increasing by one, while the value is actually added to the old map, and so the new map will never reach full size, unless I am mistaken.