### PR TITLE
Use original key value to report counter within reportMetered, add test

### DIFF
--- a/ffwd-reporter/src/main/java/com/spotify/metrics/ffwd/FastForwardReporter.java
+++ b/ffwd-reporter/src/main/java/com/spotify/metrics/ffwd/FastForwardReporter.java
@@ -297,6 +297,7 @@ public class FastForwardReporter implements AutoCloseable {
     }
 
     private void reportMetered(MetricId key, Meter value) {
+        MetricId originalKey = key;
         key = MetricId.join(prefix, key);
 
         final Metric m = FastForward
@@ -305,7 +306,7 @@ public class FastForwardReporter implements AutoCloseable {
             .attribute(METRIC_TYPE, "meter");
 
         reportMetered(m, value);
-        reportCounter(key, value);
+        reportCounter(originalKey, value);
     }
 
     private void reportTimer(MetricId key, Timer value) {


### PR DESCRIPTION
https://github.com/spotify/semantic-metrics/issues/101
Before: 
![Screen Shot 2021-02-08 at 4 42 42 PM](https://user-images.githubusercontent.com/16561599/107285819-b5bbfa00-6a2d-11eb-91af-032462061939.png)
After, test passes for 
```
List<String> expectedKeys = Arrays.asList("test.hi", "test.thename", "test.thename",
        "test.thename", "test.hi", "test.thename", "test.thename", "test.thename");
```