### PR TITLE
Add Jmh benchmark submodule

### DIFF
--- a/jmh-benchmarks/README.md
+++ b/jmh-benchmarks/README.md
@@ -1,0 +1,13 @@
+To run a benchmark, build the module with:
+
+```
+mvn -am -pl jmh-benchmarks package
+```
+
+and run
+
+```
+java -classpath jmh-benchmarks/target/semantic-metrics-jmh-benchmarks.jar org.openjdk.jmh.Main [arguments]
+```
+
+add `-h` to see all possible arguments for JMH, and `-l` to list the benchmarks.

--- a/jmh-benchmarks/pom.xml
+++ b/jmh-benchmarks/pom.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.spotify.metrics</groupId>
+    <artifactId>semantic-metrics-parent</artifactId>
+    <version>1.1.9-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>semantic-metrics-jmh-benchmarks</artifactId>
+
+  <properties>
+    <jmh.version>1.23</jmh.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.spotify.metrics</groupId>
+      <artifactId>semantic-metrics-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+      <version>${jmh.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <finalName>${project.artifactId}</finalName>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-compile</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <annotationProcessorPaths>
+                <path>
+                  <groupId>org.openjdk.jmh</groupId>
+                  <artifactId>jmh-generator-annprocess</artifactId>
+                  <version>${jmh.version}</version>
+                </path>
+              </annotationProcessorPaths>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <useBaseVersion>false</useBaseVersion>
+          <overWriteReleases>false</overWriteReleases>
+          <overWriteSnapshots>true</overWriteSnapshots>
+          <includeScope>runtime</includeScope>
+          <outputDirectory>${project.build.directory}/lib</outputDirectory>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.2.0</version>
+        <executions>
+          <execution>
+            <id>default-jar</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <archive>
+            <addMavenDescriptor>true</addMavenDescriptor>
+            <manifest>
+              <addClasspath>true</addClasspath>
+              <classpathPrefix>lib/</classpathPrefix>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/jmh-benchmarks/src/main/java/com/spotify/metrics/jmh/DistributionBenchmark.java
+++ b/jmh-benchmarks/src/main/java/com/spotify/metrics/jmh/DistributionBenchmark.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2021 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.metrics.jmh;
+
+import com.codahale.metrics.Histogram;
+import com.spotify.metrics.core.Distribution;
+import com.spotify.metrics.core.SemanticMetricBuilder;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Group;
+import org.openjdk.jmh.annotations.GroupThreads;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Group)
+@BenchmarkMode(Mode.All)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Fork(value = 2, warmups = 1)
+@Measurement(time = 10, iterations = 5)
+@Warmup(time = 10, iterations = 2)
+public class DistributionBenchmark {
+
+    private Distribution distribution;
+    private Histogram histogram;
+
+    @Setup
+    public void setUp() {
+        distribution = SemanticMetricBuilder.DISTRIBUTION.newMetric();
+        histogram = SemanticMetricBuilder.HISTOGRAMS.newMetric();
+    }
+
+    @Benchmark
+    @Group("dist1")
+    @GroupThreads(1)
+    public void distThreads1() {
+        distribution.record(42.0);
+    }
+
+    @Benchmark
+    @Group("dist2")
+    @GroupThreads(2)
+    public void dist2() {
+        distribution.record(42.0);
+    }
+
+    @Benchmark
+    @Group("dist4")
+    @GroupThreads(4)
+    public void distThreads4() {
+        distribution.record(42.0);
+    }
+
+    @Benchmark
+    @Group("dist8")
+    @GroupThreads(8)
+    public void distThreads8() {
+        distribution.record(42.0);
+    }
+    @Benchmark
+    @Group("hist1")
+    @GroupThreads(1)
+    public void histThreads1() {
+        histogram.update(42);
+    }
+
+    @Benchmark
+    @Group("hist2")
+    @GroupThreads(2)
+    public void hist2() {
+        histogram.update(42);
+    }
+
+    @Benchmark
+    @Group("hist4")
+    @GroupThreads(4)
+    public void histThreads4() {
+        histogram.update(42);
+    }
+
+    @Benchmark
+    @Group("hist8")
+    @GroupThreads(8)
+    public void histThreads8() {
+        histogram.update(42);
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
     <module>ffwd-reporter</module>
     <module>examples</module>
     <module>guava</module>
+    <module>jmh-benchmarks</module>
     <module>remote</module>
     <module>semantic-metrics-bom</module>
   </modules>


### PR DESCRIPTION
Summary:
The distribution metric is faster when it's not contended,
but degrades during heavy contention.

Analysis:
Histogram throughput scales almost linearly with number of cores,
and maxes out at 52 ops/us, both with 4 and 8 threads.
Contention does not appear to be an issue there.

Distribution throughput is best when running with a single thread,
maxing out at 47 ops/us and drops down to 13 ops/us when running
with 4 threads. Going to 8 threads actually increases the throughput
though.

With a single thread, histogram runs in 0.055 us/op on average
and distribution runs in 0.021 us/op which is more than twice as fast.

However, when running with 4 threads concurrently, the distribution
average speed is 0.325 us/op (15x slower) compared to histogram which runs at
0.073 us/op (1.3x slower).

REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
experiments, perform baseline and negative tests that provide experimental control, make sure
the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
Do not assume the numbers tell you what you want them to tell.

    Benchmark                                            Mode       Cnt      Score    Error   Units
    DistributionBenchmark.dist1                         thrpt        10     47.352 ±  0.815  ops/us
    DistributionBenchmark.dist2                         thrpt        10     16.576 ±  0.142  ops/us
    DistributionBenchmark.dist4                         thrpt        10     13.032 ±  0.244  ops/us
    DistributionBenchmark.dist8                         thrpt        10     26.443 ±  0.857  ops/us
    DistributionBenchmark.hist1                         thrpt        10     18.029 ±  0.069  ops/us
    DistributionBenchmark.hist2                         thrpt        10     35.253 ±  0.570  ops/us
    DistributionBenchmark.hist4                         thrpt        10     52.909 ±  1.103  ops/us
    DistributionBenchmark.hist8                         thrpt        10     53.726 ±  1.669  ops/us
    DistributionBenchmark.dist1                          avgt        10      0.021 ±  0.001   us/op
    DistributionBenchmark.dist2                          avgt        10      0.127 ±  0.007   us/op
    DistributionBenchmark.dist4                          avgt        10      0.302 ±  0.012   us/op
    DistributionBenchmark.dist8                          avgt        10      0.325 ±  0.030   us/op
    DistributionBenchmark.hist1                          avgt        10      0.055 ±  0.001   us/op
    DistributionBenchmark.hist2                          avgt        10      0.057 ±  0.001   us/op
    DistributionBenchmark.hist4                          avgt        10      0.073 ±  0.003   us/op
    DistributionBenchmark.hist8                          avgt        10      0.148 ±  0.006   us/op
