### PR TITLE
Add synchronized around getCount dist usage

### DIFF
--- a/core/src/main/java/com/spotify/metrics/core/SemanticMetricDistribution.java
+++ b/core/src/main/java/com/spotify/metrics/core/SemanticMetricDistribution.java
@@ -75,7 +75,7 @@ public class SemanticMetricDistribution implements Distribution {
 
 
     @Override
-    public long getCount() {
+    public synchronized long getCount() {
         return distRef.get().size();
     }
 


### PR DESCRIPTION
Since TDigest objects are not thread safe, we need to protect reads from
getting corrupted data or potentially throwing exceptions.