### PR TITLE
Remove parent inheritance from BOM

### DIFF
--- a/semantic-metrics-bom/pom.xml
+++ b/semantic-metrics-bom/pom.xml
@@ -2,15 +2,10 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <groupId>com.spotify.metrics</groupId>
   <artifactId>semantic-metrics-bom</artifactId>
+  <version>1.1.9-SNAPSHOT</version>
   <name>Semantic Metrics: Bill Of Materials</name>
-
-  <parent>
-    <groupId>com.spotify.metrics</groupId>
-    <artifactId>semantic-metrics-parent</artifactId>
-    <version>1.1.9-SNAPSHOT</version>
-    <relativePath>..</relativePath>
-  </parent>
 
   <description>
     Semantic Metrics: Bill Of Materials
@@ -21,29 +16,44 @@
       <dependency>
         <groupId>com.spotify.metrics</groupId>
         <artifactId>semantic-metrics-api</artifactId>
-        <version>${project.parent.version}</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>com.spotify.metrics</groupId>
         <artifactId>semantic-metrics-core</artifactId>
-        <version>${project.parent.version}</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>com.spotify.metrics</groupId>
         <artifactId>semantic-metrics-ffwd-reporter</artifactId>
-        <version>${project.parent.version}</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>com.spotify.metrics</groupId>
         <artifactId>semantic-metrics-guava</artifactId>
-        <version>${project.parent.version}</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>com.spotify.metrics</groupId>
         <artifactId>semantic-metrics-remote</artifactId>
-        <version>${project.parent.version}</version>
+        <version>${project.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <version>1.6.3</version>
+        <extensions>true</extensions>
+        <configuration>
+          <serverId>ossrh</serverId>
+          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+          <autoReleaseAfterClose>true</autoReleaseAfterClose>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>


### PR DESCRIPTION
Inheriting a parent from a Maven BOM will leak all dependencies in the
<dependancyManagement> section in the parent through the BOM. This
removes that inheritance and adds configuration to the BOM to allow for
releases to work.