### PR TITLE
bom: add packaging pom

### DIFF
--- a/semantic-metrics-bom/pom.xml
+++ b/semantic-metrics-bom/pom.xml
@@ -5,6 +5,7 @@
   <groupId>com.spotify.metrics</groupId>
   <artifactId>semantic-metrics-bom</artifactId>
   <version>1.1.11-SNAPSHOT</version>
+  <packaging>pom</packaging>
   <name>Semantic Metrics: Bill Of Materials</name>
 
   <description>


### PR DESCRIPTION
Although using this pom as a bom seems to work as expected, the maven ModelBuilder yields a model with `jar` packaging when parsing this artifact.