### PR TITLE
Add idle metric to InstrumentedExecutorService.InstrumentedCallable

### DIFF
--- a/core/src/main/java/com/spotify/metrics/core/InstrumentedExecutorService.java
+++ b/core/src/main/java/com/spotify/metrics/core/InstrumentedExecutorService.java
@@ -225,13 +225,17 @@ public class InstrumentedExecutorService implements ExecutorService {
 
     private class InstrumentedCallable<T> implements Callable<T> {
         private final Callable<T> callable;
+        private final Timer.Context idleContext;
+
 
         InstrumentedCallable(Callable<T> callable) {
             this.callable = callable;
+            this.idleContext = idle.time();
         }
 
         @Override
         public T call() throws Exception {
+            idleContext.stop();
             running.inc();
             final Timer.Context context = duration.time();
             try {


### PR DESCRIPTION
The `InstrumentedExecutorService` class is based on the [implementation from dropwizard][1]. Shortly after the Spotify version of this class was created in 2018, dropwizard added an idle metric to the nested`InstrumentedCallable` class in [this PR][2], to track how long it takes for the callable to be invoked.

This PR adds the idle metric to the Spotify implementation.

[1]: https://github.com/dropwizard/metrics/blob/c1d0fb9b5f44ec18d686c15e419466225f2aa816/metrics-core/src/main/java/com/codahale/metrics/InstrumentedExecutorService.java
[2]: https://github.com/dropwizard/metrics/commit/295b976532386e157a7af633652feaa6c96d4e7e
