### PR TITLE
Added flush to the README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ public class Entry {
         app.start();
 
         app.join();
+        reporter.stopWithFlush();
         System.exit(0);
     }
 }


### PR DESCRIPTION
While working with your library I was struggling to understand why I wasn't seeing any metric emitted. Turns our it was because my app exited without flushing my metrics.

Adding this line to the example may help others in my situation.