### PR TITLE
Don't report empty histograms to FastForward

### DIFF
--- a/ffwd-reporter/src/main/java/com/spotify/metrics/ffwd/FastForwardReporter.java
+++ b/ffwd-reporter/src/main/java/com/spotify/metrics/ffwd/FastForwardReporter.java
@@ -286,6 +286,11 @@ public class FastForwardReporter implements AutoCloseable {
     }
 
     private void reportHistogram(MetricId key, Histogram value) {
+        final Snapshot snapshot = value.getSnapshot();
+        if (snapshot.size() == 0) {
+            return;
+        }
+
         key = MetricId.join(prefix, key);
 
         final Metric m = FastForward
@@ -293,7 +298,7 @@ public class FastForwardReporter implements AutoCloseable {
             .attributes(key.getTags())
             .attribute(METRIC_TYPE, "histogram");
 
-        reportHistogram(m, value.getSnapshot());
+        reportHistogram(m, snapshot);
     }
 
     private void reportMetered(MetricId key, Meter value) {
@@ -310,6 +315,11 @@ public class FastForwardReporter implements AutoCloseable {
     }
 
     private void reportTimer(MetricId key, Timer value) {
+        final Snapshot snapshot = value.getSnapshot();
+        if (snapshot.size() == 0) {
+            return;
+        }
+
         key = MetricId.join(prefix, key);
 
         final Metric m = FastForward
@@ -319,7 +329,7 @@ public class FastForwardReporter implements AutoCloseable {
             .attribute("unit", "ns");
 
         reportMetered(m, value);
-        reportHistogram(m, value.getSnapshot());
+        reportHistogram(m, snapshot);
     }
 
     private void reportDerivingMeter(MetricId key, DerivingMeter value) {


### PR DESCRIPTION
*Rationale*

If histograms don't have any reported values, or have not been used
in a long time, the snapshot is empty and the histogram metrics
will not have a reasonable default value. All stats (min, max, median, etc) would
incorrectly be reported as zero

*Performance impact*

The performance impact should be minimal, since it only adds one additional
if-check when reporting histograms. Snapshot.size() is a fast method, simply
returning the length of its internal array.

For cases where snapshots are empty - i.e. unused histograms we should see
a performance improvement since we can skip emitting the data points to FastForward
as well as skipping the creation of the metric ids.