### PR TITLE
Add JVM Memory Usage Ratio

### DIFF
--- a/core/src/main/java/com/spotify/metrics/jvm/MemoryUsageGaugeSet.java
+++ b/core/src/main/java/com/spotify/metrics/jvm/MemoryUsageGaugeSet.java
@@ -115,6 +115,16 @@ public class MemoryUsageGaugeSet implements SemanticMetricSet {
                 return memoryUsageSupplier.get().getCommitted();
             }
         });
+
+        gauges.put(nonHeap.tagged("memory_category", "used_ratio"), new Gauge<Long>() {
+            @Override
+            public Long getValue() {
+                if (memoryUsageSupplier.get().getMax() <= 0) {
+                    return 1L;
+                }
+                return memoryUsageSupplier.get().getUsed() / memoryUsageSupplier.get().getMax();
+            }
+        });
     }
 
     private interface MemoryUsageSupplier {


### PR DESCRIPTION
This would be a good addition for usecases where the monitoring backend doesn't support alerting on combined time series. Usage ratio is a good pre-indicator of situations where an application instance start throwing OOM exceptions.